### PR TITLE
GUI Touch Screen Functionality, Parallel Coordinates Graph and other minor fixes

### DIFF
--- a/Core/BoundaryPointModel.cpp
+++ b/Core/BoundaryPointModel.cpp
@@ -30,6 +30,15 @@ std::vector<BoundaryPoint*> BoundaryPointModel::controlPoints() {
     return ctlPoints;
 }
 
+std::vector<BoundaryPoint*> BoundaryPointModel::boundaryPoints() {
+    std::vector<BoundaryPoint*> boundaryPoints;
+    for( auto& bp : mBoundaryPoints) {
+        boundaryPoints.push_back(&bp);
+    }
+
+    return boundaryPoints;
+}
+
 void BoundaryPointModel::setPoints(std::list<std::pair<float, float> > points)
 {
     for (auto coord : points)

--- a/Core/BoundaryPointModel.h
+++ b/Core/BoundaryPointModel.h
@@ -100,6 +100,13 @@ public:
      */
     std::vector<BoundaryPoint *> controlPoints();
 
+    /**
+     * @brief boundaryPoints Returns ths list of all boundary points in the model.
+     * @return List of boundary points
+     */
+    std::vector<BoundaryPoint*> boundaryPoints();
+
+
 signals:
     /**
      * @brief boundaryPointsReset Emits when a new / blank list of boundary points is instantaited.

--- a/Core/Enumerations.h
+++ b/Core/Enumerations.h
@@ -35,10 +35,10 @@ namespace Enum
      */
     enum OptMethod
     {
-        METHODNOTSET = 0,
         MCS,            // Modified Cuckoo search
-        DE,             // Differential Evolution
-        PSO             // Particle Swarm Optimisation
+        DE,             //Differential Evolution
+        PSO,            // Particle Swarm Optimisation
+        METHODNOTSET
     };
 
     /**

--- a/Core/Optimisation.cpp
+++ b/Core/Optimisation.cpp
@@ -204,6 +204,10 @@ QString Optimisation::simulationDirectoryName() {
     return fileName;
 }
 
+std::vector<BoundaryPoint*> Optimisation::initialBoundaryPoints() {
+    return mBoundaryPoints;
+}
+
 std::vector<BoundaryPoint*> Optimisation::controlPoints() {
     return mControlPoints;
 }
@@ -214,6 +218,10 @@ void Optimisation::setControlPoints(std::vector<BoundaryPoint*> controlPoints) {
 
 int Optimisation::controlPointCount() {
     return mControlPoints.size();
+}
+
+void Optimisation::setBoundaryPoints(std::vector<BoundaryPoint*> boundaryPoints) {
+    mBoundaryPoints = boundaryPoints;
 }
 
 QString Optimisation::simulationDirectoryPath() {
@@ -268,92 +276,6 @@ bool Optimisation::readProfilePointsFromSimulationDir() {
     bool success = profile.setFile(filePath);
     mProfilePoints = profile.getProfile();
 
-
-    // Load Control node coordinates
-    QString cpfilePath = simulationDirectoryPath() + "/Control_Nodes.txt";
-    QDir::toNativeSeparators(cpfilePath);
-    std::ifstream cpInfile(cpfilePath.toStdString(), std::ifstream::in);
-    success &= cpInfile.is_open();
-
-    // Initialise BoundaryPointObjects with coordinates
-    if (success) {
-        QVector<BoundaryPoint*> controlPs;
-        std::string line("");
-        QString qline;
-
-        //Convert input file into BoundaryPoints
-        while (std::getline(cpInfile, line))
-        {
-            qline = QString::fromStdString(line);
-            QStringList strList = qline.split("\t");
-            QString xstr = strList.at(0);
-            QString ystr = strList.at(1);
-            double x = xstr.toDouble();
-            double y = ystr.toDouble();
-            BoundaryPoint* bp = new BoundaryPoint(x,y);
-            bp->setControlPoint(true);
-            controlPs.append(bp);
-        }
-        this->setControlPoints(controlPs.toStdVector());
-    }
-
-
-    // Add Bounding Boxes to Control Points
-    QString inputFilePath = simulationDirectoryPath() + "/AerOpt_InputParameters.txt";
-    std::ifstream bbInfile(inputFilePath.toStdString(), std::ifstream::in);
-    success &= bbInfile.is_open();
-
-    if (success)
-    {
-        QString qline, value;
-        QStringList strList;
-        std::string variable;
-        std::string line("");
-
-        while (std::getline(bbInfile, line))
-        {
-            qline = QString::fromStdString(line);
-            strList = qline.split(QRegExp("\\s*=\\s*"));
-
-            if(strList.length()==2) {
-                variable = strList.at(0).toStdString();
-                value = strList.at(1);
-
-                if(variable == "IV%xrange") {
-                    QStringList xrange = strList.at(1).split(QRegExp("\\s+"), QString::SkipEmptyParts);
-
-                    for (int i = 0; i < xrange.size()/2; i++) {
-
-                        double left = xrange.at(i).toDouble();
-                        double right = xrange.at(i).toDouble();
-
-                        this->controlPoints().at(i)->controlPointRect().setLeft(left);
-                        this->controlPoints().at(i)->controlPointRect().setRight(right);
-                    }
-                }
-                else if(variable == "IV%yrange") {
-                    QStringList yrange = strList.at(1).split(QRegExp("\\s+"), QString::SkipEmptyParts);
-
-                    for (int i = 0; i < yrange.size()/2; i++) {
-                        double top = yrange.at(i).toDouble();
-                        double bottom = yrange.at(i).toDouble();
-
-                        this->controlPoints().at(i)->controlPointRect().setTop(top);
-                        this->controlPoints().at(i)->controlPointRect().setBottom(bottom);
-                    }
-                }
-                else if(variable == "IV%smoothfactor") {
-                    QStringList smoothfactor = strList.at(1).split(QRegExp("\\s+"), QString::SkipEmptyParts);
-
-                    for (int i = 0; i < smoothfactor.size(); i++) {
-                        double sf = smoothfactor.at(i).toDouble();
-                        this->controlPoints().at(i)->setSmoothing(sf);
-                    }
-                }
-
-            }
-        }
-    }
     return success;
 }
 
@@ -373,6 +295,7 @@ bool Optimisation::run() {
     QSettings settings;
     QString AerOptInFile = settings.value("AerOpt/inputFile").toString();
     QString AerOptNodeFile = settings.value("AerOpt/nodeFile").toString();
+    QString AerOptBoundaryFile = settings.value("AerOpt/boundaryFile").toString();
     QString meshDatFile = settings.value("mesher/initMeshFile").toString();
     QString AerOpt = settings.value("AerOpt/executable").toString();
     QString AerOptWorkDir = settings.value("AerOpt/workingDirectory").toString();
@@ -393,6 +316,7 @@ bool Optimisation::run() {
     //Set input files in input directory
     r &= createAerOptInFile(AerOptInFile);
     r &= createAerOptNodeFile(AerOptNodeFile);
+    r &= createAerOptBoundaryPointFile(AerOptBoundaryFile);
 
     //then run aeropt
     if (r)
@@ -418,6 +342,7 @@ bool Optimisation::run() {
         }
         copyFileToSimulationDir(AerOptInFile);
         copyFileToSimulationDir(AerOptNodeFile);
+        copyFileToSimulationDir(AerOptBoundaryFile);
         writeProfilePointsToSimulationDir();
     }
     else
@@ -611,6 +536,53 @@ bool Optimisation::createAerOptNodeFile(const QString& filePath)
                     << std::to_string(point->y())
                     << std::endl;
         }
+    }
+    outfile.close();
+
+    return r;
+}
+
+bool Optimisation::createAerOptBoundaryPointFile(const QString &filePath) {
+
+    bool r = true;
+
+    std::ofstream outfile(filePath.toStdString(), std::ofstream::out);
+    r &= outfile.is_open();
+
+    if (r)
+    {
+        std::string xcoord;
+        std::string ycoord;
+        std::string controlPoint;
+        std::string smoothingFactor;
+        std::string xmin;
+        std::string xmax;
+        std::string ymin;
+        std::string ymax;
+
+        for (auto& point : mBoundaryPoints)
+        {
+            xcoord += std::to_string(point->x()) + "\t";
+            ycoord += std::to_string(point->y()) + "\t";
+            controlPoint += std::to_string(point->isControlPoint()) + "\t";
+            smoothingFactor += std::to_string(point->getSmoothFactor()) + "\t";
+            xmin += std::to_string(point->controlPointRect().left()) + "\t";
+            xmax += std::to_string(point->controlPointRect().right()) + "\t";
+            ymin += std::to_string(point->controlPointRect().top()) + "\t";
+            ymax += std::to_string(point->controlPointRect().bottom()) + "\t";
+
+        }
+
+        // Boundary Point Info
+        outfile << "IV%x = " << xcoord << std::endl;
+        outfile << "IV%y = " << ycoord << std::endl;
+        outfile << "IV%isCP = " << controlPoint << std::endl;
+        outfile << "IV%smoothingFactor = " << smoothingFactor << std::endl;
+        outfile << "IV%xMin = " << xmin << std::endl;
+        outfile << "IV%xMax = " << xmax << std::endl;
+        outfile << "IV%yMin = " << ymin << std::endl;
+        outfile << "IV%yMax = " << ymax << std::endl;
+
     }
     outfile.close();
 
@@ -948,6 +920,7 @@ bool Optimisation::load(QString aerOptInputFilePath) {
     success &= readAerOptSettings(aerOptInputFilePath);
     success &= readFitness();
     success &= readProfilePointsFromSimulationDir();
+    success &= readInitialBoundaryPoints();
     success &= readLogFromFile();
 
     return success;
@@ -997,4 +970,112 @@ bool Optimisation::readLogFromFile() {
     }
 
     return true;
+}
+
+bool Optimisation::readInitialBoundaryPoints() {
+
+    QString filePath = simulationDirectoryPath() + "/Boundary_Points.txt";
+    bool success = true;
+    std::ifstream infile(filePath.toStdString(), std::ifstream::in);
+    success &= infile.is_open();
+
+    QString qline, value;
+    QStringList strList;
+    std::string variable;
+
+    if (success)
+    {
+        std::string line("");
+
+        QStringList x;
+        QStringList y;
+        QStringList isCP;
+        QStringList sf;
+        QStringList xMin;
+        QStringList xMax;
+        QStringList yMin;
+        QStringList yMax;
+
+        while (std::getline(infile, line))
+        {
+            qline = QString::fromStdString(line);
+            strList = qline.split(QRegExp("\\s*=\\s*"));
+
+            if(strList.length()==2) {
+                variable = strList.at(0).toStdString();
+                value = strList.at(1);
+
+                if(variable == "IV%x") {
+                    x = strList.at(1).split("\t", QString::SkipEmptyParts);
+
+                } else if(variable == "IV%y") {
+                    y = strList.at(1).split("\t", QString::SkipEmptyParts);
+
+                } else if(variable == "IV%isCP") {
+                    isCP = strList.at(1).split("\t", QString::SkipEmptyParts);
+
+                } else if(variable == "IV%smoothingFactor") {
+                    sf = strList.at(1).split("\t", QString::SkipEmptyParts);
+
+                } else if(variable == "IV%xMin") {
+                    xMin = strList.at(1).split("\t", QString::SkipEmptyParts);
+
+                } else if(variable == "IV%xMax") {
+                    xMax = strList.at(1).split("\t", QString::SkipEmptyParts);
+
+                } else if(variable == "IV%yMin") {
+                    yMin = strList.at(1).split("\t", QString::SkipEmptyParts);
+
+                } else if(variable == "IV%yMax") {
+                    yMax = strList.at(1).split("\t", QString::SkipEmptyParts);
+
+                }
+            }
+        }
+
+        std::vector<BoundaryPoint*> boundaryPs;
+        std::vector<BoundaryPoint*> controlPs;
+
+        for (int i = 0; i< x.size(); i++) {
+            QString xstr = x.at(i);
+            QString ystr = y.at(i);
+            QString isCPstr = isCP.at(i);
+            QString sfstr = sf.at(i);
+            QString xMinstr = xMin.at(i);
+            QString xMaxstr = xMax.at(i);
+            QString yMinstr = yMin.at(i);
+            QString yMaxstr = yMax.at(i);
+            double xVal = xstr.toDouble();
+            double yVal = ystr.toDouble();
+            bool isCPVal = false;
+                if (isCPstr.toInt() == 1) isCPVal = true;
+            double sfVal = sfstr.toDouble();
+            double xMinVal = xMinstr.toDouble();
+            double xMaxVal = xMaxstr.toDouble();
+            double yMinVal = yMinstr.toDouble();
+            double yMaxVal = yMaxstr.toDouble();
+
+            BoundaryPoint* bp = new BoundaryPoint(xVal,yVal);
+            bp->setControlPoint(isCPVal);
+            bp->setSmoothing(sfVal);
+
+            QRectF boundingBox = *new QRectF(xMinVal, yMinVal, xMaxVal - xMinVal, yMaxVal - yMinVal);
+
+            bp->setControlPointRect(boundingBox);
+            boundaryPs.push_back(bp);
+            if (isCPVal){
+                controlPs.push_back(bp);
+            }
+
+        }
+
+        this->setBoundaryPoints(boundaryPs);
+        this->setControlPoints(controlPs);
+
+        // Add Bounding Boxes to Control Points
+        QString inputFilePath = simulationDirectoryPath() + "/AerOpt_InputParameters.txt";
+        std::ifstream bbInfile(inputFilePath.toStdString(), std::ifstream::in);
+        success &= bbInfile.is_open();
+
+    }
 }

--- a/Core/Optimisation.cpp
+++ b/Core/Optimisation.cpp
@@ -369,6 +369,7 @@ bool Optimisation::createAerOptInFile(const QString& filePath)
 
     if (r)
     {
+
         std::string xrange;
         std::string mxrange;
         std::string yrange;
@@ -377,18 +378,11 @@ bool Optimisation::createAerOptInFile(const QString& filePath)
 
         for (auto& point : controlPoints())
         {
-            QRectF rect = point->controlPointRect();
-            float smoothFactor = point->getSmoothFactor();
-
-            xrange += " " + std::to_string(rect.right());
-
-            yrange += " " + std::to_string(rect.bottom());
-
-            mxrange += " " + std::to_string(rect.left());
-
-            myrange += " " + std::to_string(rect.top());
-
-            smoothing += " " + std::to_string(smoothFactor);
+            xrange += " " + std::to_string(point->controlPointRect().right());
+            yrange += " " + std::to_string(point->controlPointRect().bottom());
+            mxrange += " " + std::to_string(point->controlPointRect().left());
+            myrange += " " + std::to_string(point->controlPointRect().top());
+            smoothing += " " + std::to_string(point->getSmoothFactor());
         }
 
         Enum::OptMethod optMethod = getOptimisationMethod();
@@ -407,6 +401,7 @@ bool Optimisation::createAerOptInFile(const QString& filePath)
             optMethodIndex = -1;
             break;
         }
+
 
         outfile << "&inputVariables" << std::endl;
         outfile << "IV%Ma = " << std::to_string( machNo() ) << std::endl;
@@ -529,10 +524,11 @@ bool Optimisation::createAerOptNodeFile(const QString& filePath)
         std::string yrange;
         std::string myrange;
 
+
         for (auto& point : controlPoints())
         {
             outfile << std::to_string(point->x())
-                    << "	"
+                    << "\t"
                     << std::to_string(point->y())
                     << std::endl;
         }

--- a/Core/Optimisation.cpp
+++ b/Core/Optimisation.cpp
@@ -795,6 +795,20 @@ std::pair<double,double> Optimisation::fitnessRange() {
     return minMax;
 }
 
+std::pair<double,double> Optimisation::fitnessRangeBestAgents() {
+    std::pair<double,double> minMax;
+    minMax.first = std::numeric_limits<double>::infinity();
+    minMax.second = -std::numeric_limits<double>::infinity();
+
+    for(auto& gen : mFitness){
+        if(gen.at(0) < minMax.first)
+            minMax.first = gen.at(0);
+        if(gen.at(0) > minMax.second)
+            minMax.second = gen.at(0);
+    }
+    return minMax;
+}
+
 QString Optimisation::outputText() {
     return mOutputLog;
 }

--- a/Core/Optimisation.h
+++ b/Core/Optimisation.h
@@ -160,11 +160,15 @@ public:
      * @param returns the method index as defined by ordering in OptimiserDialog.ui.
      */
     Enum::OptMethod getOptimisationMethod() const;
-    /**
-     * @brief readFitness
-     * @param read the fitness for this optimisation
-     */
+
+
     bool readFitness();
+
+    /**
+     * @brief getProfile Returns the initial optimisation Profile
+     * @return
+     */
+    ProfilePoints getProfile();
     /**
      * @brief mesh
      * @param getter method for meshes
@@ -179,24 +183,78 @@ public:
     int getNoTop() const;
     void setNoTop(int noTop);
 
+    /**
+     * @brief label Returns the identification label / optimisation name.
+     * @return Optimisation identification label.
+     */
     QString label() const;
     QString simulationDirectoryName();
     QString simulationDirectoryPath();
+
+    /**
+     * @brief setLabel Set the identification label
+     * @param label Optimisation label.
+     */
     void setLabel(QString label);
     Mesh *initMesh();
 
     // control nodes
+    /**
+     * @brief controlPoints Returns a vector of all Boundary Points that are control nodes.
+     * @return Vector of Boundary Points that are control nodes
+     */
     std::vector<BoundaryPoint*> controlPoints();
+
+    /**
+     * @brief setControlPoints Sets the vector of control nodes.
+     * @param controlPoints A vector of Boundary Points for which isControlPoint == true
+     */
     void setControlPoints(std::vector<BoundaryPoint*> controlPoints);
+
+    /**
+     * @brief controlPointCount Returns the number of control points to optimise.
+     * @return The number of control points
+     */
     int controlPointCount();
 
     bool run();
+
+    /**
+     * @brief setModel Set the model that this optimisation belongs to.
+     * @param model
+     */
     void setModel(OptimisationModel* model);
+
+    /**
+     * @brief allfitness Returns a 2D vector of the fitnesses for all agents in each generation.
+     * @return 2D Vector of fitness values
+     */
     std::vector<std::vector<double>> allfitness();
+
+    /**
+     * @brief fitness Returns the fitness of a given agent within a specified generation.
+     * @param generationIndex Generation number
+     * @param agentIndex Agent index
+     * @return The fitness of the given agent in the specified generation
+     */
     double fitness(int generationIndex, int agentIndex);
+
+    /**
+     * @brief outputText Returns the output log.
+     * @return The output log
+     */
     QString outputText();
+
+    /**
+     * @brief fitnessRange Returns the minimum and maximum fitness values for this optimisation, across all generations.
+     * @return A pair of double values of the format <minimum, maximum>.
+     */
     std::pair<double,double> fitnessRange();
 
+    /**
+     * @brief initProfilePoints Returns the initial profile.
+     * @return mProfilePoints
+     */
     ProfilePoints initProfilePoints();
 
     bool runOnCluster = false;
@@ -209,13 +267,32 @@ private:
     bool saveCurrentProfile(const QString& path);
     QString outputDataDirectory();
     bool readAerOptSettings(QString filePath);
+
+    /**
+     * @brief addToOutputLog Adds a line to mOutputLog and the output log file.
+     * @param line Text to add to output log
+     */
     void addToOutputLog(const QString line);
 
     void writeProfilePointsToSimulationDir();
     bool readProfilePointsFromSimulationDir();
+
+    /**
+     * @brief setInitProfilePoints Set the initial profile.
+     * @param profilePoints The initial profile.
+     */
     void setInitProfilePoints(ProfilePoints profilePoints);
 
+    /**
+     * @brief readLogFromFile Load the output log into mOutputLog from the log file as defined in logCacheFileName().
+     * @return true iff file loaded successfully
+     */
     bool readLogFromFile();
+
+    /**
+     * @brief logCacheFileName Returns the file path for the output log file.
+     * @return Output log file directory path.
+     */
     QString logCacheFileName();
 
     // copy files
@@ -223,34 +300,93 @@ private:
     QString aerOptNodeFileCopyPath();
     QString aerOptInputFileCopyPath();
 
+    /**
+     * Identification label / optimisation name
+    */
     QString mLabel = "";
 
 	//Objective function attributes
+    /**
+     * @brief mObjFunc Fitness function that agents are being optimised for.
+     */
     Enum::ObjFunc mObjFunc;
 
 	//Boundary condition attributes
+    /**
+     * @brief mMachNo Mach number
+     */
 	float mMachNo;
+
+    /**
+     * @brief mReNo Reynolds Number
+     */
 	float mReNo;
+
+    /**
+     * @brief mFreeAlpha Angle of Attack
+     */
 	float mFreeAlpha;
+
+    /**
+     * @brief mFreePress Pressure Absolute
+     */
 	float mFreePress;
+
+    /**
+     * @brief mFreeTemp Temperature Absolute
+     */
 	float mFreeTemp;
 
 	//Optimiser parameters
+    /**
+     * @brief mOptimisationMethod Optimisation Algorithm
+     */
     Enum::OptMethod mOptimisationMethod;
+
+    /**
+     * @brief mNoAgents Number of agents
+     */
 	int mNoAgents;
+
+    /**
+     * @brief mNoGens Number of generations
+     */
 	int mNoGens;
+
+    /**
+     * @brief mNoTop
+     */
     int mNoTop;
 
     Mesh* mInitMesh;
+
+    /**
+     * @brief mControlPoints Vector of Boundary Points that are also optimisable control nodes.
+     */
     std::vector<BoundaryPoint*> mControlPoints;
+
+    /**
+     * @brief mFitness 2D vector of fitnesses for all agents across all generations.
+     * Indexed by <generation number<agent index>>.
+     */
     std::vector<std::vector<double>> mFitness;
 
     ProcessManager* mProcess = nullptr;
 
+    /**
+     * @brief mOptimisationModel Model that this optimisation belongs to.
+     */
     OptimisationModel* mOptimisationModel;
 
+    /**
+     * @brief mOutputLog Process output log
+     */
     QString mOutputLog = "";
 
+    /**
+     * @brief mProfilePoints The original profile before any optimisation.
+     * E.g. NACA0024 or NACA21120
+     */
     ProfilePoints mProfilePoints;
 
     clusterManager* clusterChecker = nullptr;

--- a/Core/Optimisation.h
+++ b/Core/Optimisation.h
@@ -259,6 +259,13 @@ public:
     std::pair<double,double> fitnessRange();
 
     /**
+     * @brief fitnessRange Returns the minimum and maximum fitness values for the
+     * best agents of each generation in this optimisation.
+     * @return A pair of double values of the format <minimum, maximum>.
+     */
+    std::pair<double,double> fitnessRangeBestAgents();
+
+    /**
      * @brief initProfilePoints Returns the initial profile.
      * @return mProfilePoints
      */

--- a/Core/Optimisation.h
+++ b/Core/Optimisation.h
@@ -46,10 +46,11 @@ public:
 	 */
 	bool boundary() const;
 	/**
-	 * @brief setBoundary
+     * @brief setBoundary Set list of mesh boundary points
 	 * @param boundary Sets the boundary.
 	 */
-	void setBoundary(bool boundary);
+    void setBoundaryPoints(std::vector<BoundaryPoint*> boundaryPoints);
+
 	/**
 	 * @brief optimiser
 	 * @return True if optimiser is set.
@@ -206,6 +207,12 @@ public:
     std::vector<BoundaryPoint*> controlPoints();
 
     /**
+     * @brief boundaryPoints Returns a vector of all boundary points of the initial mesh.
+     * @return
+     */
+    std::vector<BoundaryPoint*> initialBoundaryPoints();
+
+    /**
      * @brief setControlPoints Sets the vector of control nodes.
      * @param controlPoints A vector of Boundary Points for which isControlPoint == true
      */
@@ -264,6 +271,13 @@ private:
     void optimiserFinished(int exitCode, QProcess::ExitStatus exitStatus);
     bool createAerOptInFile(const QString &filePath);
     bool createAerOptNodeFile(const QString &filePath);
+
+    /**
+     * @brief createAerOptBoundaryPointFile Writes boundary point information for initial mesh.
+     * @param filePath File location
+     * @return true iff file written successfully
+     */
+    bool createAerOptBoundaryPointFile(const QString &filePath);
     bool saveCurrentProfile(const QString& path);
     QString outputDataDirectory();
     bool readAerOptSettings(QString filePath);
@@ -289,6 +303,11 @@ private:
      */
     bool readLogFromFile();
 
+    /**
+     * @brief readInitialBoundaryPoints Load the initial boundary points.
+     * @return true iff file loaded successfully.
+     */
+    bool readInitialBoundaryPoints();
     /**
      * @brief logCacheFileName Returns the file path for the output log file.
      * @return Output log file directory path.
@@ -364,6 +383,11 @@ private:
      * @brief mControlPoints Vector of Boundary Points that are also optimisable control nodes.
      */
     std::vector<BoundaryPoint*> mControlPoints;
+
+    /**
+     * @brief mBoundaryPoints Vector of all Boundary Points.
+     */
+    std::vector<BoundaryPoint*> mBoundaryPoints;
 
     /**
      * @brief mFitness 2D vector of fitnesses for all agents across all generations.

--- a/Core/Optimisation.h
+++ b/Core/Optimisation.h
@@ -269,7 +269,19 @@ public:
 
 private:
     void optimiserFinished(int exitCode, QProcess::ExitStatus exitStatus);
+
+    /**
+     * @brief createAerOptInFile Writes optimisation data to an external file.
+     * @param filePath File location
+     * @return true iff file written successfully
+     */
     bool createAerOptInFile(const QString &filePath);
+
+    /**
+     * @brief createAerOptNodeFile Writes control node coordinates to an external file.
+     * @param filePath File location
+     * @return true iff file written successfully
+     */
     bool createAerOptNodeFile(const QString &filePath);
 
     /**

--- a/GeneticGui.pro
+++ b/GeneticGui.pro
@@ -50,6 +50,7 @@ TEMPLATE = app
 
 SOURCES += \
     Gui/GuiComponents/ParallelCoordinatesWindow.cpp \
+    Gui/GuiComponents/chart.cpp \
     main.cpp \
     Gui/DebugOutput.cpp \
     Gui/Dialogs/MeshDialog.cpp \
@@ -86,6 +87,7 @@ HEADERS  += \
     Gui/DebugOutput.h \
     Gui/Dialogs/MeshDialog.h \
     Gui/GuiComponents/ParallelCoordinatesWindow.h \
+    Gui/GuiComponents/chart.h \
     Gui/Plotter/qcustomplot.h \
     Gui/Dialogs/ConfigSimulationDialog.h \
     Gui/MainWindow.h \

--- a/GeneticGui.pro
+++ b/GeneticGui.pro
@@ -49,7 +49,7 @@ TARGET = AerOptGui
 TEMPLATE = app
 
 SOURCES += \
-    Gui/GuiComponents/ParallelCoordinatesPlotter.cpp \
+    Gui/GuiComponents/ParallelCoordinatesWindow.cpp \
     main.cpp \
     Gui/DebugOutput.cpp \
     Gui/Dialogs/MeshDialog.cpp \
@@ -85,7 +85,7 @@ SOURCES += \
 HEADERS  += \
     Gui/DebugOutput.h \
     Gui/Dialogs/MeshDialog.h \
-    Gui/GuiComponents/ParallelCoordinatesPlotter.h \
+    Gui/GuiComponents/ParallelCoordinatesWindow.h \
     Gui/Plotter/qcustomplot.h \
     Gui/Dialogs/ConfigSimulationDialog.h \
     Gui/MainWindow.h \
@@ -120,6 +120,7 @@ HEADERS  += \
 FORMS    += \
     Gui/DebugOutput.ui \
     Gui/Dialogs/ConfigSimulationDialog.ui \
+    Gui/GuiComponents/ParallelCoordinatesWindow.ui \
     Gui/MainWindow.ui \
     Gui/Dialogs/MeshDialog.ui \
     Gui/GuiComponents/ControlPointView.ui \

--- a/GeneticGui.pro
+++ b/GeneticGui.pro
@@ -49,6 +49,7 @@ TARGET = AerOptGui
 TEMPLATE = app
 
 SOURCES += \
+    Gui/GuiComponents/ChartView.cpp \
     Gui/GuiComponents/ParallelCoordinatesWindow.cpp \
     Gui/GuiComponents/chart.cpp \
     main.cpp \
@@ -86,6 +87,7 @@ SOURCES += \
 HEADERS  += \
     Gui/DebugOutput.h \
     Gui/Dialogs/MeshDialog.h \
+    Gui/GuiComponents/ChartView.h \
     Gui/GuiComponents/ParallelCoordinatesWindow.h \
     Gui/GuiComponents/chart.h \
     Gui/Plotter/qcustomplot.h \

--- a/GeneticGui.pro
+++ b/GeneticGui.pro
@@ -7,6 +7,7 @@
 QT  += \
     core \
     widgets \
+    charts \
     printsupport
 
 CONFIG(debug, debug|release) {
@@ -48,6 +49,7 @@ TARGET = AerOptGui
 TEMPLATE = app
 
 SOURCES += \
+    Gui/GuiComponents/ParallelCoordinatesPlotter.cpp \
     main.cpp \
     Gui/DebugOutput.cpp \
     Gui/Dialogs/MeshDialog.cpp \
@@ -83,6 +85,7 @@ SOURCES += \
 HEADERS  += \
     Gui/DebugOutput.h \
     Gui/Dialogs/MeshDialog.h \
+    Gui/GuiComponents/ParallelCoordinatesPlotter.h \
     Gui/Plotter/qcustomplot.h \
     Gui/Dialogs/ConfigSimulationDialog.h \
     Gui/MainWindow.h \

--- a/Gui/Dialogs/ConfigSimulationDialog.cpp
+++ b/Gui/Dialogs/ConfigSimulationDialog.cpp
@@ -106,6 +106,7 @@ void ConfigSimulationDialog::accept()
 
 void ConfigSimulationDialog::on_optmethod_currentIndexChanged(int index)
 {
+    //This line isn't too effective as if the enum indexing changes it breaks
     bool isMCS = (static_cast<Enum::OptMethod>(index) == Enum::OptMethod::MCS);
 
     if(isMCS) {

--- a/Gui/Dialogs/ConfigSimulationDialog.h
+++ b/Gui/Dialogs/ConfigSimulationDialog.h
@@ -24,6 +24,12 @@ public slots:
     void accept();
 
 private slots:
+
+    /**
+     * @brief on_optmethod_currentIndexChanged When the index of the optmethod dropdown box changes, then enable ndiscard,
+     * otherwise disable ndiscard as MCS is the only optimisation method that has this parameter
+     * @param index Index of item in selected in dropdown box
+     */
     void on_optmethod_currentIndexChanged(int index);
 
 private:

--- a/Gui/Dialogs/MeshDialog.cpp
+++ b/Gui/Dialogs/MeshDialog.cpp
@@ -114,6 +114,10 @@ std::vector<BoundaryPoint*> MeshDialog::controlPoints() {
     return mMeshDialogModel->boundaryPointModel()->controlPoints();
 }
 
+std::vector<BoundaryPoint*> MeshDialog::boundaryPoints() {
+    return mMeshDialogModel->boundaryPointModel()->boundaryPoints();
+}
+
 void MeshDialog::runMesher() {
     Mesh* mesh = mMeshDialogModel->currentMesh();
     mesh->setMeshDensity(ui->density->currentData().value<Enum::Mesh>());

--- a/Gui/Dialogs/MeshDialog.cpp
+++ b/Gui/Dialogs/MeshDialog.cpp
@@ -1,4 +1,3 @@
-
 #include "MeshDialog.h"
 #include "ui_MeshDialog.h"
 #include "ControlPointView.h"
@@ -40,6 +39,9 @@ MeshDialog::MeshDialog(ProfileModel &profileModel, MeshDialogModel* model, QWidg
     connect(ui->zoomSlider,&QSlider::valueChanged,[this](int scale) {
         ui->graphicsView->setTransform(QTransform::fromScale(float(scale)/100, float(scale)/100));;
     });
+
+    connect(ui->graphicsView, &ZoomPanView::scaleChanged,
+            this, &MeshDialog::scaleZoomBarValue);
 
     connect(&mProfileModel, &ProfileModel::newProfileAdded, [this](int index) {
         ui->profile->setCurrentIndex(index);
@@ -83,6 +85,11 @@ MeshDialog::MeshDialog(ProfileModel &profileModel, MeshDialogModel* model, QWidg
     setProfile();
 
     centerAndResizeWindow(this, 0.8, 0.8);
+}
+
+
+void MeshDialog::scaleZoomBarValue(double value){
+    ui->zoomSlider->setValue(ui->zoomSlider->value() * value);
 }
 
 void MeshDialog::setProfile() {

--- a/Gui/Dialogs/MeshDialog.h
+++ b/Gui/Dialogs/MeshDialog.h
@@ -25,7 +25,18 @@ public:
     explicit MeshDialog(ProfileModel &profileModel, MeshDialogModel *model, QWidget* parent = 0);
     ~MeshDialog();
     void accept();
+
+    /**
+     * @brief controlPoints Returns the list of boundary points that are control points.
+     * @return List of control points
+     */
     std::vector<BoundaryPoint*> controlPoints();
+
+    /**
+     * @brief controlPoints Returns the full list of boundary points.
+     * @return List of boundary points
+     */
+    std::vector<BoundaryPoint*> boundaryPoints();
 
 public slots:
     void runMesher();

--- a/Gui/Dialogs/MeshDialog.h
+++ b/Gui/Dialogs/MeshDialog.h
@@ -31,6 +31,13 @@ public slots:
     void runMesher();
     void setProfile();
 
+    /**
+     * @brief scaleZoomBarValue Scale the value of the zoom bar slider in response to changed in the view transformation.
+     * Included validation check which places a limit on hte
+     * @param value Scaling value
+     */
+    void scaleZoomBarValue(double value);
+
 private slots:
     void on_profile_currentIndexChanged(int index);
 

--- a/Gui/GraphicsItems/BoundaryPointView.cpp
+++ b/Gui/GraphicsItems/BoundaryPointView.cpp
@@ -27,6 +27,13 @@ BoundaryPointView::BoundaryPointView(BoundaryPointModel *model, int index, ViewS
 
     connect(mBoundaryPointModel, &BoundaryPointModel::activeIndexChanged, this, &BoundaryPointView::setActivePoint);
     connect(mBoundaryPointModel, &BoundaryPointModel::controlPointStateChanged, this, &BoundaryPointView::refreshControlPointState);
+
+    // Set up click and hold timer
+    timer = new QTimer(this);
+    timer->setSingleShot(true);
+    timer->setInterval(400);
+    connect(timer, SIGNAL(timeout()), this, SLOT(timerTimeout()));
+
 }
 
 qreal BoundaryPointView::radius() const {
@@ -143,4 +150,16 @@ void BoundaryPointView::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) {
     }
 
     QGraphicsItem::mouseDoubleClickEvent(event);
+}
+
+void BoundaryPointView::mousePressEvent(QGraphicsSceneMouseEvent *event) {
+    timer->start();
+}
+
+void BoundaryPointView::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
+    timer->stop();
+}
+
+void BoundaryPointView::timerTimeout(){
+    mBoundaryPointModel->setControlPointState(mBoundaryPointIndex, !mControl);
 }

--- a/Gui/GraphicsItems/BoundaryPointView.cpp
+++ b/Gui/GraphicsItems/BoundaryPointView.cpp
@@ -31,7 +31,7 @@ BoundaryPointView::BoundaryPointView(BoundaryPointModel *model, int index, ViewS
     // Set up click and hold timer
     timer = new QTimer(this);
     timer->setSingleShot(true);
-    timer->setInterval(400);
+    timer->setInterval(300);
     connect(timer, SIGNAL(timeout()), this, SLOT(timerTimeout()));
 
 }
@@ -154,10 +154,12 @@ void BoundaryPointView::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) {
 
 void BoundaryPointView::mousePressEvent(QGraphicsSceneMouseEvent *event) {
     timer->start();
+    QGraphicsItem::mousePressEvent(event);
 }
 
 void BoundaryPointView::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
     timer->stop();
+    QGraphicsItem::mouseReleaseEvent(event);
 }
 
 void BoundaryPointView::timerTimeout(){

--- a/Gui/GraphicsItems/BoundaryPointView.cpp
+++ b/Gui/GraphicsItems/BoundaryPointView.cpp
@@ -164,4 +164,9 @@ void BoundaryPointView::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
 
 void BoundaryPointView::timerTimeout(){
     mBoundaryPointModel->setControlPointState(mBoundaryPointIndex, !mControl);
+    if (isControlPoint())
+        timer->setInterval(500);
+    else {
+        timer->setInterval(300);
+    }
 }

--- a/Gui/GraphicsItems/BoundaryPointView.h
+++ b/Gui/GraphicsItems/BoundaryPointView.h
@@ -55,6 +55,13 @@ public slots:
      */
     void refreshControlPointState(int index, bool ctl);
 
+private slots:
+
+    /**
+     * @brief timerTimeout When a the single shot timer times out, then toggle whether point is a control point.
+     */
+    void timerTimeout();
+
 private:
     /**
      * @brief activated Returns whether this Boundary Point is currently activated (selected) (AKA mActive).
@@ -106,6 +113,10 @@ private:
      */
     ViewScaler* mScale;
 
+    /**
+     * @brief timer Time for long mouse presses.
+     */
+    QTimer *timer;
 protected:
 
     /**
@@ -131,6 +142,18 @@ protected:
      * @param event QGraphicsSceneMouseEvent Mouse Click event
      */
     void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
+
+    /**
+     * @brief BoundaryPointView::mousePressEvent Starts a singleshot timer on mouse click that if triggered will call timerTimeout().
+     * @param event
+     */
+    void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+
+    /**
+     * @brief BoundaryPointView::mouseReleaseEvent Stops the timer activated by the mouse press
+     * @param event
+     */
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
 };
 
 #endif // CONTROLPOINTGRAPHICSITEM_H

--- a/Gui/GuiComponents/ChartView.cpp
+++ b/Gui/GuiComponents/ChartView.cpp
@@ -27,12 +27,15 @@
 **
 ****************************************************************************/
 
-#include "chartview.h"
+#include "ChartView.h"
 #include <QtGui/QMouseEvent>
+#include <QApplication>
 
 ChartView::ChartView(QWidget *parent) :
     QChartView(parent)
 {
+    setDragMode(QGraphicsView::NoDrag);
+    this->setMouseTracking(true);
 
 }
 
@@ -42,4 +45,35 @@ void ChartView::wheelEvent(QWheelEvent* event) {
     } else {
         chart()->zoomOut();
     }
+}
+
+//Credit: https://stackoverflow.com/questions/46805186/qt-chart-move-view-with-pressed-middle-mouse-button
+void ChartView::mousePressEvent(QMouseEvent *event)
+{
+    if (event->button() == Qt::LeftButton)
+    {
+        QApplication::setOverrideCursor(QCursor(Qt::SizeAllCursor));
+        m_lastMousePos = event->pos();
+        event->accept();
+    }
+
+    QChartView::mousePressEvent(event);
+}
+
+//Credit: https://stackoverflow.com/questions/46805186/qt-chart-move-view-with-pressed-middle-mouse-button
+void ChartView::mouseMoveEvent(QMouseEvent *event)
+{
+    // pan the chart with a middle mouse drag
+    if (event->buttons() & Qt::LeftButton)
+    {
+        auto dPos = event->pos() - m_lastMousePos;
+        chart()->scroll(-dPos.x(), dPos.y());
+
+        m_lastMousePos = event->pos();
+        event->accept();
+
+        QApplication::restoreOverrideCursor();
+    }
+
+    QChartView::mouseMoveEvent(event);
 }

--- a/Gui/GuiComponents/ChartView.cpp
+++ b/Gui/GuiComponents/ChartView.cpp
@@ -1,0 +1,45 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the Qt Charts module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:GPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3 or (at your option) any later version
+** approved by the KDE Free Qt Foundation. The licenses are as published by
+** the Free Software Foundation and appearing in the file LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "chartview.h"
+#include <QtGui/QMouseEvent>
+
+ChartView::ChartView(QWidget *parent) :
+    QChartView(parent)
+{
+
+}
+
+void ChartView::wheelEvent(QWheelEvent* event) {
+    if(event->delta() > 0) {
+        chart()->zoomIn();
+    } else {
+        chart()->zoomOut();
+    }
+}

--- a/Gui/GuiComponents/ChartView.h
+++ b/Gui/GuiComponents/ChartView.h
@@ -1,0 +1,52 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the Qt Charts module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:GPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3 or (at your option) any later version
+** approved by the KDE Free Qt Foundation. The licenses are as published by
+** the Free Software Foundation and appearing in the file LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef CHARTVIEW_H
+#define CHARTVIEW_H
+
+#include <QtCharts/QChartView>
+
+QT_CHARTS_USE_NAMESPACE
+
+//![1]
+class ChartView : public QChartView
+//![1]
+{
+public:
+    ChartView(QWidget *parent = nullptr);
+
+//![2]
+protected:
+    void wheelEvent(QWheelEvent *event);
+//![2]
+
+private:
+};
+
+#endif

--- a/Gui/GuiComponents/ChartView.h
+++ b/Gui/GuiComponents/ChartView.h
@@ -43,10 +43,32 @@ public:
 
 //![2]
 protected:
-    void wheelEvent(QWheelEvent *event);
+    /**
+     * @brief wheelEvent Scale the view on mouse scroll wheel movement.
+     * @param event
+     */
+    void wheelEvent(QWheelEvent *event) override;
+
+    /**
+     * @brief mousePressEvent Listen out for mouse click events to begin panning.
+     * @param event
+     */
+    void mousePressEvent(QMouseEvent *event) override;
+
+    /**
+     * @brief mouseMoveEvent Pan chart while left mouse button is clicked and mouse moves.
+     * @param event
+     */
+    void mouseMoveEvent(QMouseEvent *event) override;
 //![2]
 
 private:
+    /**
+     * @brief m_lastMousePos Last recorded mouse position.
+     * Used for panning.
+     */
+    QPointF m_lastMousePos;
+
 };
 
 #endif

--- a/Gui/GuiComponents/ParallelCoordinatesPlotter.cpp
+++ b/Gui/GuiComponents/ParallelCoordinatesPlotter.cpp
@@ -1,0 +1,103 @@
+#include "ParallelCoordinatesPlotter.h"
+#include "QWidget"
+#include <QtCharts/QLineSeries>
+#include <QtCharts/QValueAxis>
+#include <QtCharts/QCategoryAxis>
+#include "BoundaryPoint.h"
+#include "Mesh.h"
+#include <QDebug>
+
+QT_CHARTS_USE_NAMESPACE
+
+ParallelCoordinatesPlotter::ParallelCoordinatesPlotter(QWidget *parent) : QWidget(parent)
+{
+    this->resize(1200, 500);
+    //QWidget::showFullScreen();
+}
+
+void ParallelCoordinatesPlotter::setOptimisationModel(OptimisationModel* model) {
+    mOptimisationModel = model;
+}
+
+Optimisation* ParallelCoordinatesPlotter::currentOptimisation() {
+    return mOptimisationModel->optimisation(mCurrentOptimisationIndex);
+}
+
+void ParallelCoordinatesPlotter::setCurrentOptimisationIndex(int index) {
+    mCurrentOptimisationIndex = index;
+    boundaryPointGraph();
+}
+
+QChartView* ParallelCoordinatesPlotter::getGraph(){
+    return chartView;
+}
+
+void ParallelCoordinatesPlotter::boundaryPointGraph(){
+
+    // Set up chart object
+    QChart *chart = new QChart();
+    //chart->legend()->hide();
+    chart->setTitle("Parallel Coordinates");
+
+    // Fetch the number of generations
+    int numberOfGenerations = currentOptimisation()->noGens();
+    QLineSeries *series;
+
+    // Initialise axes
+    QCategoryAxis *axisX = new QCategoryAxis;
+    QValueAxis *axisY = new QValueAxis;
+
+
+    int bpCount = 0;
+
+    //For each generation
+    for(int g = 0; g < numberOfGenerations; g++){
+
+        //Pick best agent (index  = 0)
+        Mesh* currentMesh = currentOptimisation()->mesh(g, 0);
+        ProfilePoints currentMeshProfile = currentMesh->boundaryPoints();
+
+        // Loop through each boundary point and add a plot to the series
+        series = new QLineSeries();
+        bpCount = 0;
+        for (ProfilePoints::iterator it = currentMeshProfile.begin(); it != currentMeshProfile.end(); ++it) {
+            *series << QPointF(2*bpCount, it->first) << QPointF(2*bpCount+1, it->second);
+            bpCount++;
+        }
+
+        // Attach Last BP series to graph
+        series->attachAxis(axisX);
+        series->attachAxis(axisY);
+        series->setName("Generation " + QString::number(g+1));
+        chart->addSeries(series);
+
+    }
+
+    // Set up X axis
+    chart->addAxis(axisX, Qt::AlignBottom);
+    for (int i = 0; i < bpCount; i++){
+        axisX->append("BP_" + QString::number(i) + "_X", 2*i);
+        axisX->append("BP_" + QString::number(i) + "_Y", 2*i+1);
+    }
+    axisX->setTickCount(bpCount);
+    axisX->setRange(0, bpCount*2 - 1);
+    //chart->axes(Qt::Vertical).first()->setRange(0, bpCount*2);
+
+    // Set up Y axis
+    axisY->setTickCount(11);
+    axisY->setRange(0,1); // values are normalised
+    chart->addAxis(axisY, Qt::AlignLeft);
+
+    // Render widget
+    chartView = new QChartView(chart);
+    chartView->setRenderHint(QPainter::Antialiasing);
+    chartView->setParent(this);
+    chartView->resize(this->width(),this->height());
+    chartView->show();
+
+}
+
+double ParallelCoordinatesPlotter::normalise(double x, double xMin, double xMax){
+    return (x-xMin) / (xMax - xMin);
+}
+

--- a/Gui/GuiComponents/ParallelCoordinatesPlotter.cpp
+++ b/Gui/GuiComponents/ParallelCoordinatesPlotter.cpp
@@ -11,7 +11,12 @@ QT_CHARTS_USE_NAMESPACE
 
 ParallelCoordinatesPlotter::ParallelCoordinatesPlotter(QWidget *parent) : QWidget(parent)
 {
-    this->resize(1200, 500);
+    if (parent == nullptr){
+        this->resize(1200, 500);
+    } else{
+        this->resize(parent->width(),parent->height());
+    }
+    //this->resize(1200, 500);
     //QWidget::showFullScreen();
 }
 
@@ -25,23 +30,39 @@ Optimisation* ParallelCoordinatesPlotter::currentOptimisation() {
 
 void ParallelCoordinatesPlotter::setCurrentOptimisationIndex(int index) {
     mCurrentOptimisationIndex = index;
-    boundaryPointGraph();
+    drawGraph(CONTROL_POINT);
 }
 
 QChartView* ParallelCoordinatesPlotter::getGraph(){
     return chartView;
 }
 
-void ParallelCoordinatesPlotter::boundaryPointGraph(){
+void ParallelCoordinatesPlotter::drawGraph(GraphType type){
 
     // Set up chart object
     QChart *chart = new QChart();
-    //chart->legend()->hide();
     chart->setTitle("Parallel Coordinates");
 
-    // Fetch the number of generations
-    int numberOfGenerations = currentOptimisation()->noGens();
-    QLineSeries *series;
+    switch(type){
+        case CONTROL_POINT:
+            chart = controlPointGraph(chart);
+            break;
+
+        case BOUNDARY_POINT:
+            chart = boundaryPointGraph(chart);
+            break;
+    }
+
+    // Render widget
+    chartView = new QChartView(chart);
+    chartView->setRenderHint(QPainter::Antialiasing);
+    chartView->setParent(this);
+    chartView->resize(this->width(),this->height());
+    chartView->show();
+
+}
+
+QChart* ParallelCoordinatesPlotter::boundaryPointGraph(QChart *chart){
 
     // Initialise axes
     QCategoryAxis *axisX = new QCategoryAxis;
@@ -73,29 +94,124 @@ void ParallelCoordinatesPlotter::boundaryPointGraph(){
 
     }
 
-    // Set up X axis
-    chart->addAxis(axisX, Qt::AlignBottom);
-    for (int i = 0; i < bpCount; i++){
-        axisX->append("BP_" + QString::number(i) + "_X", 2*i);
-        axisX->append("BP_" + QString::number(i) + "_Y", 2*i+1);
+
+QChart* ParallelCoordinatesPlotter::controlPointGraph(QChart *chart) {
+
+    // Initialise axes
+    QCategoryAxis *axisX = new QCategoryAxis;
+    QValueAxis *axisY = new QValueAxis;
+
+
+    // Fetch the number of control points
+    int numberOfControlPoints  = currentOptimisation()->controlPointCount();
+    std::vector<BoundaryPoint*> controlPoints = currentOptimisation()->controlPoints();
+    int controlPointIndexes[numberOfControlPoints]; //Index of control points among boundary points
+
+    // Get the indexes of all control points in the mesh
+    std::vector<BoundaryPoint*> initialBoundary = currentOptimisation()->initialBoundaryPoints();
+
+    for (int bp = 0; bp < initialBoundary.size(); bp++) {
+
+        for (int cp = 0; cp < numberOfControlPoints; cp++) {
+
+            // If x/y coordinates are the same then this is a control point
+            if (initialBoundary.at(bp)->x() == controlPoints[cp]->x()
+                    && initialBoundary.at(bp)->y() == controlPoints[cp]->y()) {
+
+                controlPointIndexes[cp] = bp;
+                break;
+            }
+        }
     }
-    axisX->setTickCount(bpCount);
-    axisX->setRange(0, bpCount*2 - 1);
-    //chart->axes(Qt::Vertical).first()->setRange(0, bpCount*2);
+
+    // Bounding box limit values for normalisation
+    double minXValues[numberOfControlPoints];
+    double minYValues[numberOfControlPoints];
+    double maxXValues[numberOfControlPoints];
+    double maxYValues[numberOfControlPoints];
+
+    // Get min/max X/Y bounding box limits
+    for(int cp = 0; cp< numberOfControlPoints; cp++){
+        minXValues[cp] = controlPoints[cp]->controlPointRect().left();
+        minYValues[cp] = controlPoints[cp]->controlPointRect().top();
+        maxXValues[cp] = controlPoints[cp]->controlPointRect().right();
+        maxYValues[cp] = controlPoints[cp]->controlPointRect().bottom();
+    }
+
+
+    //
+    // Set up axes
+    //
+    // Set up X axis
+    for (int i = 0; i < numberOfControlPoints; i++){
+        axisX->append("X" + QString::number(i), 2*i);
+        axisX->append("Y" + QString::number(i), 2*i+1);
+    }
+    axisX->setTickCount(numberOfControlPoints);
+    //May need to change range back to 0
+    axisX->setRange(-1, numberOfControlPoints*2);
+    axisX->setTitleText("Control Points");
+    axisX->AxisLabelsPositionOnValue;
+    chart->addAxis(axisX, Qt::AlignBottom);
 
     // Set up Y axis
     axisY->setTickCount(11);
     axisY->setRange(0,1); // values are normalised
+    axisY->setTitleText("Normalised Values");
     chart->addAxis(axisY, Qt::AlignLeft);
 
-    // Render widget
-    chartView = new QChartView(chart);
-    chartView->setRenderHint(QPainter::Antialiasing);
-    chartView->setParent(this);
-    chartView->resize(this->width(),this->height());
-    chartView->show();
+
+
+    // Fetch the number of generations
+    int numberOfGenerations = currentOptimisation()->noGens();
+    QLineSeries *series;
+
+    //For each generation
+    for(int g = 0; g < numberOfGenerations; g++){
+
+
+
+        //Pick best agent
+        //(at current, agents are returned in fitness-descending order from the optimiser so index  = 0)
+        Mesh* bestAgent = currentOptimisation()->mesh(g, 0);
+        ProfilePoints currentMeshProfile = bestAgent->boundaryPoints();
+
+        // Loop through each control point and add a plot to the series
+        series = new QLineSeries();
+        for (int cpCount = 0; cpCount < numberOfControlPoints; cpCount++) {
+
+            for (ProfilePoints::iterator it = currentMeshProfile.begin(); it != currentMeshProfile.end(); ++it) {
+                if (bpCount == controlPointIndexes[cpCount]) {
+                    double xmin = initialBoundary.at(cpCount)->pos().x() + minXValues[cpCount];
+                    double xmax = initialBoundary.at(cpCount)->pos().x() + maxXValues[cpCount];
+                    double ymin = initialBoundary.at(cpCount)->pos().y() + minYValues[cpCount];
+                    double ymax = initialBoundary.at(cpCount)->pos().y()+ maxYValues[cpCount];
+
+                    qInfo() << "BP" + QString::number(bpCount) + "x = " + QString::number(it->first) + ", min = " + QString::number(xmin) + ", max = " + QString::number(xmax) + ", norm = " + QString::number(normalise(it->first, xmin, xmax));
+                    //normalise actual X/Y values for this agent w.r.t the bounding box limits
+                    //Add normalised values to series
+
+                    *series << QPointF(2*cpCount, normalise(it->first, xmin, xmax));
+                    *series << QPointF(2*cpCount+1, normalise(it->second, ymin, ymax));
+                    break;
+                }
+
+                bpCount++;
+            }
+        }
+
+        // Add new series to chart
+        chart->addSeries(series);
+        series->attachAxis(axisX);
+        series->attachAxis(axisY);
+        series->setName("Generation " + QString::number(g+1));
+
+    }
+
+    return chart;
 
 }
+
 
 double ParallelCoordinatesPlotter::normalise(double x, double xMin, double xMax){
     return (x-xMin) / (xMax - xMin);

--- a/Gui/GuiComponents/ParallelCoordinatesPlotter.cpp
+++ b/Gui/GuiComponents/ParallelCoordinatesPlotter.cpp
@@ -63,12 +63,6 @@ void ParallelCoordinatesPlotter::drawGraph(GraphType type){
 
 }
 
-
-
-    // Initialise axes
-    QCategoryAxis *axisX = new QCategoryAxis;
-    QValueAxis *axisY = new QValueAxis;
-
 QChart* ParallelCoordinatesPlotter::plotGraph(bool showAll) {
 
     QChart *chart = new QChart();
@@ -89,6 +83,10 @@ QChart* ParallelCoordinatesPlotter::plotGraph(bool showAll) {
     //
     // Set up axes
     //
+    // Initialise axes
+    QCategoryAxis *axisX = new QCategoryAxis;
+    QValueAxis *axisY = new QValueAxis;
+
     // Set up X axis
     int numberOfGraphPoints;
     if (showAll){

--- a/Gui/GuiComponents/ParallelCoordinatesPlotter.cpp
+++ b/Gui/GuiComponents/ParallelCoordinatesPlotter.cpp
@@ -44,13 +44,13 @@ void ParallelCoordinatesPlotter::drawGraph(GraphType type){
 
     switch(type){
         case CONTROL_POINT:
-            chart->setTitle("Control Point Displacement");
             chart = plotGraph(false);
+            chart->setTitle("Control Point Displacement");
             break;
 
         case BOUNDARY_POINT:
-            chart->setTitle("Boundary Point Displacement");
             chart = plotGraph(true);
+            chart->setTitle("Boundary Point Displacement");
             break;
     }
 

--- a/Gui/GuiComponents/ParallelCoordinatesPlotter.cpp
+++ b/Gui/GuiComponents/ParallelCoordinatesPlotter.cpp
@@ -124,20 +124,6 @@ QChart* ParallelCoordinatesPlotter::controlPointGraph(QChart *chart) {
         }
     }
 
-    // Bounding box limit values for normalisation
-    double minXValues[numberOfControlPoints];
-    double minYValues[numberOfControlPoints];
-    double maxXValues[numberOfControlPoints];
-    double maxYValues[numberOfControlPoints];
-
-    // Get min/max X/Y bounding box limits
-    for(int cp = 0; cp< numberOfControlPoints; cp++){
-        minXValues[cp] = controlPoints[cp]->controlPointRect().left();
-        minYValues[cp] = controlPoints[cp]->controlPointRect().top();
-        maxXValues[cp] = controlPoints[cp]->controlPointRect().right();
-        maxYValues[cp] = controlPoints[cp]->controlPointRect().bottom();
-    }
-
 
     //
     // Set up axes

--- a/Gui/GuiComponents/ParallelCoordinatesPlotter.h
+++ b/Gui/GuiComponents/ParallelCoordinatesPlotter.h
@@ -81,14 +81,16 @@ private:
     void drawGraph(GraphType type);
 
     /**
-     * @brief boundaryPointGraph Draws a parallel coordinate graph of all boundary points in the current optimisation.
+     * @brief plotGraph Draws a parallel coordinates chart of normalised displacement of boundary points.
+     * Can either return a chart with all Boundary Points, or just with Boundary Points that are Control Points.
+     * @param showAll
+     * @return
      */
-    QChart* boundaryPointGraph(QChart *chart);
+    QChart* plotGraph(bool showAll);
 
     /**
-     * @brief controlPointGraph Draws a parallel coordinate graph of all control points in the current optimisation.
      */
-    QChart* controlPointGraph(QChart *chart);
+    QChart* blankGraph(QChart *chart);
 
     /**
      * @brief chartView The Parallel Coordinates Graph
@@ -106,7 +108,5 @@ private:
     double normalise(double x, double xMin, double xMax);
 
 };
-
-
 
 #endif // PARALLELCOORDINATESPLOTTER_H

--- a/Gui/GuiComponents/ParallelCoordinatesPlotter.h
+++ b/Gui/GuiComponents/ParallelCoordinatesPlotter.h
@@ -1,0 +1,92 @@
+#ifndef PARALLELCOORDINATESPLOTTER_H
+#define PARALLELCOORDINATESPLOTTER_H
+#include <QWidget>
+#include "OptimisationModel.h"
+#include "Optimisation.h"
+#include <QtCharts/QChartView>
+#include <QtCharts/QLineSeries>
+#include <QtCharts/QValueAxis>
+
+QT_CHARTS_USE_NAMESPACE
+class ParallelCoordinatesPlotter : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit ParallelCoordinatesPlotter(QWidget *parent = nullptr);
+
+    /**
+     * @brief setOptimisationModel Sets the optimisation model.
+     * @param model The model of loaded optimisations.
+     */
+    void setOptimisationModel(OptimisationModel* model);
+
+    /**
+     * @brief setCurrentOptimisationIndex Set the optimisation to display data for.
+     * @param index Index of optimisation in optimisation model.
+     */
+    void setCurrentOptimisationIndex(int index);
+
+    /**
+     * @brief getGraph Returns the Parallel Coordinates graph
+     * @return
+     */
+    QChartView* getGraph();
+
+signals:
+
+public slots:
+
+
+private:
+
+    /**
+     * @brief mOptimisationModel Model of all loaded optimisations.
+     */
+    OptimisationModel* mOptimisationModel;
+
+    /**
+     * @brief mCurrentOptimisationIndex Index of currently selected optimisation in model.
+     */
+    int mCurrentOptimisationIndex = -1;
+
+    /**
+     * @brief currentOptimisation Returns the currently selected optimisation.
+     * @return
+     */
+    Optimisation* currentOptimisation();
+    // Display size
+    /**
+     * @brief mPointSize The diameter of plotted points.
+     */
+    int mPointSize = 15;
+
+    /**
+     * @brief mLineSize The thickness of plotted lines.
+     */
+    int mLineSize = 5;
+
+    /**
+     * @brief boundaryPointGraph Draws a parallel coordinate graph of all boundary points in the current optimisation.
+     */
+    void boundaryPointGraph();
+
+    /**
+     * @brief chartView The Parallel Coordinates Graph
+     */
+    QChartView *chartView = nullptr;
+
+    /**
+     * @brief normalise Simple feature scaling method of normalisation that transforms x into a value between 0 and 1,
+     * based on the minimum and maximum range values given.
+     * @param x The value to normalise
+     * @param xMin Minimum possible value in range
+     * @param xMax Maximum possible value in range
+     * @return Normalised value of x
+     */
+    double normalise(double x, double xMin, double xMax);
+
+};
+
+
+
+#endif // PARALLELCOORDINATESPLOTTER_H

--- a/Gui/GuiComponents/ParallelCoordinatesPlotter.h
+++ b/Gui/GuiComponents/ParallelCoordinatesPlotter.h
@@ -32,6 +32,16 @@ public:
      */
     QChartView* getGraph();
 
+    /**
+     * @brief The GraphType enum Type of graph to plot
+     */
+    enum GraphType
+    {
+        CONTROL_POINT,         // Parallel Coordinate Graph of Control Points only
+        BOUNDARY_POINT,        // Parallel Coordinate Graph of all boundary points
+
+    };
+
 signals:
 
 public slots:
@@ -66,9 +76,19 @@ private:
     int mLineSize = 5;
 
     /**
+     * @brief drawGraph
+     */
+    void drawGraph(GraphType type);
+
+    /**
      * @brief boundaryPointGraph Draws a parallel coordinate graph of all boundary points in the current optimisation.
      */
-    void boundaryPointGraph();
+    QChart* boundaryPointGraph(QChart *chart);
+
+    /**
+     * @brief controlPointGraph Draws a parallel coordinate graph of all control points in the current optimisation.
+     */
+    QChart* controlPointGraph(QChart *chart);
 
     /**
      * @brief chartView The Parallel Coordinates Graph

--- a/Gui/GuiComponents/ParallelCoordinatesPlotter.h
+++ b/Gui/GuiComponents/ParallelCoordinatesPlotter.h
@@ -107,6 +107,15 @@ private:
      */
     double normalise(double x, double xMin, double xMax);
 
+    /**
+     * @brief rgb Returns a QColor between Red and Blue based on a normalised value
+     * @param ratio Normalised value between 0 and 1 where 0 is Red and 1 is Blue
+     * @return QColor
+     */
+    QColor* rgb(double ratio);
+
+
+
 };
 
 #endif // PARALLELCOORDINATESPLOTTER_H

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
@@ -281,7 +281,13 @@ Chart* ParallelCoordinatesWindow::plotGraph(bool showAll) {
 
 
 double ParallelCoordinatesWindow::normalise(double x, double xMin, double xMax){
-    return (x-xMin) / (xMax - xMin);
+    //Makes sure a number is returned if all values are the same - to make sure correct colours generated
+    //If all values are the same then default colour is blue (0).
+    if (x == xMin && x == xMax){
+        return 0;
+    } else {
+        return (x-xMin) / (xMax - xMin);
+    }
 }
 
 // Credit: https://stackoverflow.com/questions/40629345/fill-array-dynamicly-with-gradient-color-c

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
@@ -166,8 +166,18 @@ Chart* ParallelCoordinatesWindow::plotGraph(bool showAll) {
     }
 
     for (int i = 0; i < numberOfGraphPoints; i++){
-        axisX->append("X" + QString::number(i), 2*i);
-        axisX->append("Y" + QString::number(i), 2*i+1);
+
+        if(showAll && currentOptimisation()->initialBoundaryPoints().at(i)->isControlPoint()){
+            axisX->append("X" + QString::number(i+1) + "*", 2*i);
+            axisX->append("Y" + QString::number(i+1) + "*", 2*i+1);
+        } else if (showAll) {
+            axisX->append("X" + QString::number(i+1), 2*i);
+            axisX->append("Y" + QString::number(i+1), 2*i+1);
+        } else {
+            axisX->append("X" + QString::number(i+1) + "*", 2*i);
+            axisX->append("Y" + QString::number(i+1) + "*", 2*i+1);
+        }
+
     }
     axisX->setTickCount(numberOfGraphPoints);
     //May need to change range back to 0

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
@@ -179,7 +179,7 @@ Chart* ParallelCoordinatesWindow::plotGraph(bool showAll) {
     }
     axisX->setTickCount(numberOfGraphPoints);
     //May need to change range back to 0
-    axisX->setRange(-1, numberOfGraphPoints*2);
+    axisX->setRange(0, (numberOfGraphPoints*2)-1);
     axisX->setLabelsPosition(axisX->AxisLabelsPositionOnValue);
     chart->addAxis(axisX, Qt::AlignBottom);
 

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
@@ -4,7 +4,7 @@
 #include <QtCharts/QCategoryAxis>
 #include <QtCharts/QValueAxis>
 #include <QtCharts/QLineSeries>
-#include <QtCharts/QChartView>
+#include "ChartView.h"
 
 #include "OptimisationModel.h"
 #include "Optimisation.h"
@@ -17,7 +17,7 @@ ParallelCoordinatesWindow::ParallelCoordinatesWindow(QWidget *parent) :
 {
     ui->setupUi(this);
     //Possibly draw blank graph here
-    chartView = new QChartView();
+    chartView = new ChartView();
     ui->verticalLayout->addWidget(chartView, 1);
 }
 

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
@@ -85,9 +85,6 @@ void ParallelCoordinatesWindow::drawGraph(GraphType type){
     // If either the optimsation model or index is not set then draw blank graph
     if (mOptimisationModel == nullptr || mCurrentOptimisationIndex < 0) {
         type = BLANK;
-    // If the optimisation is set, but incomplete then draw blank graph
-    } else if (currentOptimisation()->allfitness().size() < currentOptimisation()->noGens()){
-        type = BLANK;
     }
 
 
@@ -129,7 +126,7 @@ Chart* ParallelCoordinatesWindow::plotGraph(bool showAll) {
     int numberOfBoundaryPoints = currentOptimisation()->initialBoundaryPoints().size();
 
     // Fetch the number of generations
-    int numberOfGenerations = currentOptimisation()->noGens();
+    int numberOfGenerations = currentOptimisation()->allfitness().size();
 
     // Fetch min and max fitness values
     std::pair<double,double> fitnessRange = currentOptimisation()->fitnessRangeBestAgents();

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
@@ -16,9 +16,7 @@ ParallelCoordinatesWindow::ParallelCoordinatesWindow(QWidget *parent) :
     ui(new Ui::ParallelCoordinatesWindow)
 {
     ui->setupUi(this);
-    //Possibly draw blank graph here
     chartView = new ChartView();
-    //chartView->setRubberBand(QChartView::RectangleRubberBand);
     ui->verticalLayout->addWidget(chartView, 1);
     drawGraph(BLANK);
 
@@ -286,7 +284,7 @@ double ParallelCoordinatesWindow::normalise(double x, double xMin, double xMax){
     return (x-xMin) / (xMax - xMin);
 }
 
-
+// Credit: https://stackoverflow.com/questions/40629345/fill-array-dynamicly-with-gradient-color-c
 QColor* ParallelCoordinatesWindow::rgb(double ratio)
 {
     //Flip so red is high and blue is low

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
@@ -137,7 +137,7 @@ Chart* ParallelCoordinatesWindow::plotGraph(bool showAll) {
     chart->addAxis(axisX, Qt::AlignBottom);
 
     // Set up Y axis
-    axisY->setTickCount(21);
+    axisY->setTickCount(11);
     axisY->setRange(0,1); // values are normalised
     axisY->setTitleText("Normalised Displacement Values");
     chart->addAxis(axisY, Qt::AlignLeft);

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
@@ -8,6 +8,7 @@
 
 #include "OptimisationModel.h"
 #include "Optimisation.h"
+#include "chart.h"
 
 QT_CHARTS_USE_NAMESPACE
 ParallelCoordinatesWindow::ParallelCoordinatesWindow(QWidget *parent) :
@@ -60,7 +61,7 @@ QChartView* ParallelCoordinatesWindow::getGraph(){
 void ParallelCoordinatesWindow::drawGraph(GraphType type){
 
     // Set up chart object
-    QChart *chart;
+    Chart *chart;
 
     switch(type){
         case CONTROL_POINT:
@@ -74,6 +75,7 @@ void ParallelCoordinatesWindow::drawGraph(GraphType type){
             break;
 
         default:
+            chart = blankGraph();
             break;
 
     }
@@ -85,9 +87,9 @@ void ParallelCoordinatesWindow::drawGraph(GraphType type){
 }
 
 
-QChart* ParallelCoordinatesWindow::plotGraph(bool showAll) {
+Chart* ParallelCoordinatesWindow::plotGraph(bool showAll) {
 
-    QChart *chart = new QChart();
+    Chart *chart = new Chart();
 
     // Fetch the number of control points
     int numberOfControlPoints  = currentOptimisation()->controlPointCount();

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.cpp
@@ -18,6 +18,7 @@ ParallelCoordinatesWindow::ParallelCoordinatesWindow(QWidget *parent) :
     ui->setupUi(this);
     //Possibly draw blank graph here
     chartView = new ChartView();
+    //chartView->setRubberBand(QChartView::RectangleRubberBand);
     ui->verticalLayout->addWidget(chartView, 1);
     drawGraph(BLANK);
 
@@ -34,8 +35,13 @@ void ParallelCoordinatesWindow::setOptimisationModel(OptimisationModel* model){
 
 void ParallelCoordinatesWindow::setCurrentOptimisationIndex(int index){
     if(index != mCurrentOptimisationIndex){
+
+        // If displaying for first time
+        if (mCurrentOptimisationIndex == -1){
+            currentlyDisplayedGraph = CONTROL_POINT;
+        }
         mCurrentOptimisationIndex = index;
-        drawGraph(CONTROL_POINT);
+        update();
     }
 }
 
@@ -46,11 +52,11 @@ Optimisation* ParallelCoordinatesWindow::currentOptimisation() {
 void ParallelCoordinatesWindow::on_switchGraphButton_clicked()
 {
     if (ui->switchGraphButton->isChecked()){
-        drawGraph(BOUNDARY_POINT);
+        currentlyDisplayedGraph = BOUNDARY_POINT;
     } else {
-        drawGraph(CONTROL_POINT);
+        currentlyDisplayedGraph = CONTROL_POINT;
     }
-    chartView->repaint();
+    update();
 
 }
 
@@ -85,6 +91,8 @@ void ParallelCoordinatesWindow::drawGraph(GraphType type){
     // If either the optimsation model or index is not set then draw blank graph
     if (mOptimisationModel == nullptr || mCurrentOptimisationIndex < 0) {
         type = BLANK;
+    } else {
+        currentlyDisplayedGraph = type;
     }
 
 
@@ -113,6 +121,7 @@ void ParallelCoordinatesWindow::drawGraph(GraphType type){
     // Render widget
     chartView->setChart(chart);
     chartView->setRenderHint(QPainter::Antialiasing);
+
     //chartView->setParent(this);
 }
 
@@ -290,4 +299,9 @@ QColor* ParallelCoordinatesWindow::rgb(double ratio)
     }
 
     return new QColor(red, grn, blu);
+}
+
+void ParallelCoordinatesWindow::update(){
+    drawGraph(currentlyDisplayedGraph);
+    chartView->repaint();
 }

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.h
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.h
@@ -123,7 +123,6 @@ private:
 
     /**
      * @brief rgb Returns a QColor between Red and Blue based on a normalised value
-     * https://stackoverflow.com/questions/40629345/fill-array-dynamicly-with-gradient-color-c
      * @param ratio Normalised value between 0 and 1 where 0 is Red and 1 is Blue
      * @return QColor
      */

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.h
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.h
@@ -3,7 +3,7 @@
 
 #include <QDialog>
 #include "OptimisationModel.h"
-#include <QtCharts/QChartView>
+#include "ChartView.h"
 #include "chart.h"
 
 
@@ -93,7 +93,7 @@ private:
     /**
      * @brief chartView The Parallel Coordinates Graph
      */
-    QChartView *chartView = nullptr;
+    ChartView *chartView = nullptr;
 
     /**
      * @brief normalise Simple feature scaling method of normalisation that transforms x into a value between 0 and 1,

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.h
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.h
@@ -1,18 +1,23 @@
-#ifndef PARALLELCOORDINATESPLOTTER_H
-#define PARALLELCOORDINATESPLOTTER_H
-#include <QWidget>
+#ifndef PARALLELCOORDINATESWINDOW_H
+#define PARALLELCOORDINATESWINDOW_H
+
+#include <QDialog>
 #include "OptimisationModel.h"
-#include "Optimisation.h"
 #include <QtCharts/QChartView>
-#include <QtCharts/QLineSeries>
-#include <QtCharts/QValueAxis>
+#include <QtCharts/QChart>
+
+namespace Ui {
+class ParallelCoordinatesWindow;
+}
 
 QT_CHARTS_USE_NAMESPACE
-class ParallelCoordinatesPlotter : public QWidget
+class ParallelCoordinatesWindow : public QDialog
 {
     Q_OBJECT
+
 public:
-    explicit ParallelCoordinatesPlotter(QWidget *parent = nullptr);
+    explicit ParallelCoordinatesWindow(QWidget *parent = nullptr);
+    ~ParallelCoordinatesWindow();
 
     /**
      * @brief setOptimisationModel Sets the optimisation model.
@@ -37,17 +42,22 @@ public:
      */
     enum GraphType
     {
+        BLANK,                 // Blank Graph when an optimisation is not loaded
         CONTROL_POINT,         // Parallel Coordinate Graph of Control Points only
         BOUNDARY_POINT,        // Parallel Coordinate Graph of all boundary points
 
     };
 
-signals:
+private slots:
 
-public slots:
-
+    /**
+     * @brief on_switchGraphButton_clicked When switchGraphButton is clicked, alternate between
+     * the boundary point graph and the control point graph depending on whether the button is checked.
+     */
+    void on_switchGraphButton_clicked();
 
 private:
+    Ui::ParallelCoordinatesWindow *ui;
 
     /**
      * @brief mOptimisationModel Model of all loaded optimisations.
@@ -64,19 +74,10 @@ private:
      * @return
      */
     Optimisation* currentOptimisation();
-    // Display size
-    /**
-     * @brief mPointSize The diameter of plotted points.
-     */
-    int mPointSize = 15;
 
     /**
-     * @brief mLineSize The thickness of plotted lines.
-     */
-    int mLineSize = 5;
-
-    /**
-     * @brief drawGraph
+     * @brief drawGraph Updates chartView to return the specified graph and re-plot.
+     * @param type Specifies what kind of graph to draw based on hte GraphType Enum.
      */
     void drawGraph(GraphType type);
 
@@ -87,10 +88,6 @@ private:
      * @return
      */
     QChart* plotGraph(bool showAll);
-
-    /**
-     */
-    QChart* blankGraph(QChart *chart);
 
     /**
      * @brief chartView The Parallel Coordinates Graph
@@ -109,13 +106,12 @@ private:
 
     /**
      * @brief rgb Returns a QColor between Red and Blue based on a normalised value
+     * https://stackoverflow.com/questions/40629345/fill-array-dynamicly-with-gradient-color-c
      * @param ratio Normalised value between 0 and 1 where 0 is Red and 1 is Blue
      * @return QColor
      */
     QColor* rgb(double ratio);
 
-
-
 };
 
-#endif // PARALLELCOORDINATESPLOTTER_H
+#endif // PARALLELCOORDINATESWINDOW_H

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.h
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.h
@@ -4,7 +4,8 @@
 #include <QDialog>
 #include "OptimisationModel.h"
 #include <QtCharts/QChartView>
-#include <QtCharts/QChart>
+#include "chart.h"
+
 
 namespace Ui {
 class ParallelCoordinatesWindow;
@@ -87,7 +88,7 @@ private:
      * @param showAll
      * @return
      */
-    QChart* plotGraph(bool showAll);
+    Chart* plotGraph(bool showAll);
 
     /**
      * @brief chartView The Parallel Coordinates Graph

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.h
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.h
@@ -91,6 +91,12 @@ private:
     Chart* plotGraph(bool showAll);
 
     /**
+     * @brief blankGraph Draws a blank graph for display purposes
+     * @return Modified chart
+     */
+    Chart* blankGraph();
+
+    /**
      * @brief chartView The Parallel Coordinates Graph
      */
     ChartView *chartView = nullptr;

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.h
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.h
@@ -49,6 +49,11 @@ public:
 
     };
 
+    /**
+     * @brief update Refreshes the graph
+     */
+    void update();
+
 private slots:
 
     /**
@@ -100,6 +105,11 @@ private:
      * @brief chartView The Parallel Coordinates Graph
      */
     ChartView *chartView = nullptr;
+
+    /**
+     * @brief currentlyDisplayedGraph The type of graph we are currently displaying.
+     */
+    GraphType currentlyDisplayedGraph = BLANK;
 
     /**
      * @brief normalise Simple feature scaling method of normalisation that transforms x into a value between 0 and 1,

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.ui
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.ui
@@ -12,8 +12,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>525</width>
-    <height>373</height>
+    <width>889</width>
+    <height>544</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -24,8 +24,8 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>50</width>
-    <height>50</height>
+    <width>600</width>
+    <height>400</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.ui
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.ui
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ParallelCoordinatesWindow</class>
+ <widget class="QDialog" name="ParallelCoordinatesWindow">
+  <property name="windowModality">
+   <enum>Qt::NonModal</enum>
+  </property>
+  <property name="enabled">
+   <bool>true</bool>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>525</width>
+    <height>373</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>50</width>
+    <height>50</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Parallel Coordinates Graph</string>
+  </property>
+  <property name="autoFillBackground">
+   <bool>false</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <layout class="QHBoxLayout" name="fitnessScale">
+       <item>
+        <widget class="QLabel" name="lowLabel">
+         <property name="text">
+          <string>LOW</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="colorMap">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>20</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>2000</width>
+           <height>20</height>
+          </size>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::AutoText</enum>
+         </property>
+         <property name="pixmap">
+          <pixmap resource="../../Resourses.qrc">:/images/Map.png</pixmap>
+         </property>
+         <property name="scaledContents">
+          <bool>true</bool>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="highLabel">
+         <property name="text">
+          <string>HIGH</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QPushButton" name="switchGraphButton">
+     <property name="text">
+      <string>Show All Boundary Points</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../Resourses.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/Gui/GuiComponents/ParallelCoordinatesWindow.ui
+++ b/Gui/GuiComponents/ParallelCoordinatesWindow.ui
@@ -42,7 +42,7 @@
        <item>
         <widget class="QLabel" name="lowLabel">
          <property name="text">
-          <string>LOW</string>
+          <string>LOW FITNESS</string>
          </property>
         </widget>
        </item>
@@ -86,7 +86,7 @@
        <item>
         <widget class="QLabel" name="highLabel">
          <property name="text">
-          <string>HIGH</string>
+          <string>HIGH FITNESS</string>
          </property>
         </widget>
        </item>

--- a/Gui/GuiComponents/PlotterWidget.cpp
+++ b/Gui/GuiComponents/PlotterWidget.cpp
@@ -24,7 +24,7 @@ PlotterWidget::PlotterWidget(QWidget *parent) :
 }
 
 void PlotterWidget::validateXRangeChanged(const QCPRange &range, const QCPRange &oldRange) {
-    fixAxisRange(xAxis, range, mXMin, mXMax, mMinRange);
+    //fixAxisRange(xAxis, range, mXMin, mXMax, mMinRange);
 }
 
 void PlotterWidget::fixAxisRange(QCPAxis *axis, QCPRange range, double lowerBound, double upperBound, double minRange)

--- a/Gui/GuiComponents/PlotterWidget.cpp
+++ b/Gui/GuiComponents/PlotterWidget.cpp
@@ -119,7 +119,6 @@ void PlotterWidget::setCurrentOptimisationIndex(int index) {
 
 void PlotterWidget::updatePlot()
 {
-    bool r = true;
 
     //Get data for display
     Optimisation *opt = currentOptimisation();
@@ -131,50 +130,48 @@ void PlotterWidget::updatePlot()
     }
     int noColumns = fitness.back().size();
 
-    if (r)
+
+    //Compute ranges
+    QVector<double> x(nGens);
+    for (int i = 0; i < nGens; ++i)
     {
-
-        //Compute ranges
-        QVector<double> x(nGens);
-        for (int i = 0; i < nGens; ++i)
-        {
-            // generations are 1-indexed in GUI
-            x[i] = i + 1;
-        }
-
-
-        //for each fitness column do this
-        for (int agent = 0; agent < graphCount(); ++agent)
-        {
-            if(agent < noColumns) {
-                QVector<double> y(nGens);
-                for (int i = 0; i < nGens; ++i)
-                {
-                    y[i] = fitness.at(i).at(agent);
-                }
-                //Build graph
-                graph(agent)->setData(x, y);
-                graph(agent)->setVisible(true);
-            } else {
-                graph(agent)->setVisible(false);
-            }
-        //end do this
-        }
-
-
-        // give the axes some labels:
-        xAxis->setLabel("Generation No.");
-        yAxis->setLabel("Fitness");
-        // set axes ranges, so we see all data:
-        rescaleAxes(true);
-
-        std::pair<double, double> range = opt->fitnessRange();
-        double rangeNorm = range.second - range.first;
-        double max = range.second + rangeNorm*0.1;
-        double min = range.first - rangeNorm*0.1;
-
-        yAxis->setRange(min, max);
+        // generations are 1-indexed in GUI
+        x[i] = i + 1;
     }
+
+
+    //for each fitness column do this
+    for (int agent = 0; agent < graphCount(); ++agent)
+    {
+        if(agent < noColumns) {
+            QVector<double> y(nGens);
+            for (int i = 0; i < nGens; ++i)
+            {
+                y[i] = fitness.at(i).at(agent);
+            }
+            //Build graph
+            graph(agent)->setData(x, y);
+            graph(agent)->setVisible(true);
+        } else {
+            graph(agent)->setVisible(false);
+        }
+    //end do this
+    }
+
+
+    // give the axes some labels:
+    xAxis->setLabel("Generation No.");
+    yAxis->setLabel("Fitness");
+    // set axes ranges, so we see all data:
+    rescaleAxes(true);
+
+    std::pair<double, double> range = opt->fitnessRange();
+    double rangeNorm = range.second - range.first;
+    double max = range.second + rangeNorm*0.1;
+    double min = range.first - rangeNorm*0.1;
+
+    yAxis->setRange(min, max);
+
 
     if(opt) {
         int genRange = opt->noGens() + 1;

--- a/Gui/GuiComponents/PlotterWidget.h
+++ b/Gui/GuiComponents/PlotterWidget.h
@@ -15,7 +15,17 @@ public:
     void setCurrentOptimisationIndex(int index);
     void setCurrentlySelectedPoint(int iGen, int agent);
     void clearCurrentSelection();
+
+    /**
+     * @brief getLineSize Returns the thickness of plotted lines.
+     * @return The line thickness
+     */
     int getLineSize();
+
+    /**
+     * @brief getPointSize Returns the diameter of plotted points
+     * @return Return the point
+     */
     int getPointSize();
     void configureView(int lineSize, int pointSize);
 
@@ -33,7 +43,14 @@ private:
     double mMinRange = 3;
 
     // Display size
+    /**
+     * @brief mPointSize The diameter of plotted points
+     */
     int mPointSize = 15;
+
+    /**
+     * @brief mLineSize The thickness of plotted lines
+     */
     int mLineSize = 5;
 
     void signalCurrentlySelectedPoint();

--- a/Gui/GuiComponents/ZoomPanView.h
+++ b/Gui/GuiComponents/ZoomPanView.h
@@ -2,12 +2,16 @@
 #define ZOOMPANVIEW_H
 
 #include <QGraphicsView>
-#include <QTouchEvent>
+#include <QtGui>
+
+class QGestureEvent;
+class QPinchGesture;
 
 class ZoomPanView : public QGraphicsView
 {
+    Q_OBJECT
     public:
-        ZoomPanView(QWidget* parent = 0);
+        ZoomPanView(QWidget* parent = nullptr);
 
         /**
          * @brief ZoomPanView::wheelEvent Zoom in or out depending on direction of mouse scroll
@@ -16,16 +20,16 @@ class ZoomPanView : public QGraphicsView
         void wheelEvent(QWheelEvent* event);
 
         /**
-         * @brief touchEvent Pinch-to-Zoom action.
-         * @param touchEvent Touch screen event
-         */
-        void touchEvent(QTouchEvent* touchEvent);
-
-        /**
          * @brief ZOOM_SCALE_FACTOR
-         * Factor by which to rescale view
+         * Factor by which to rescale view with mouse wheel gestures
          */
         const double ZOOM_SCALE_FACTOR = 1.15;
+
+        /**
+         * @brief grabGestures Determines which gestures to capture.
+         * We define it to capture Pinch Gestures only.
+         */
+        void grabGestures();
 
     private:
 
@@ -35,6 +39,30 @@ class ZoomPanView : public QGraphicsView
          */
         void zoom(double scaleFactor);
 
+        /**
+         * @brief gestureEvent Handles different gestures by passing on to relevant subroutine.
+         * @param event Gesture event
+         * @return true
+         */
+        bool gestureEvent(QGestureEvent *event);
+
+        /**
+         * @brief pinchTriggered Handles pinch gestures to scale the view with zoom according to the size and direction of the pinch.
+         */
+        void pinchTriggered(QPinchGesture*);
+
+    protected:
+
+        /**
+         * @brief event Listens out for events, specifically gestures.
+         * @param event
+         * @return event
+         */
+        bool event(QEvent *event) override;
+
+
+    signals:
+        void scaleChanged(double newScale);
 };
 
 #endif // ZOOMPANVIEW_H

--- a/Gui/GuiComponents/chart.cpp
+++ b/Gui/GuiComponents/chart.cpp
@@ -1,0 +1,72 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the Qt Charts module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:GPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3 or (at your option) any later version
+** approved by the KDE Free Qt Foundation. The licenses are as published by
+** the Free Software Foundation and appearing in the file LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "chart.h"
+#include <QtWidgets/QGesture>
+#include <QtWidgets/QGraphicsScene>
+#include <QtWidgets/QGraphicsView>
+
+Chart::Chart(QGraphicsItem *parent, Qt::WindowFlags wFlags)
+    : QChart(QChart::ChartTypeCartesian, parent, wFlags)
+{
+    // Seems that QGraphicsView (QChartView) does not grab gestures.
+    // They can only be grabbed here in the QGraphicsWidget (QChart).
+    grabGesture(Qt::PanGesture);
+    grabGesture(Qt::PinchGesture);
+}
+
+Chart::~Chart()
+{
+
+}
+
+//![1]
+bool Chart::sceneEvent(QEvent *event)
+{
+    if (event->type() == QEvent::Gesture)
+        return gestureEvent(static_cast<QGestureEvent *>(event));
+    return QChart::event(event);
+}
+
+bool Chart::gestureEvent(QGestureEvent *event)
+{
+    if (QGesture *gesture = event->gesture(Qt::PanGesture)) {
+        QPanGesture *pan = static_cast<QPanGesture *>(gesture);
+        QChart::scroll(-(pan->delta().x()), pan->delta().y());
+    }
+
+    if (QGesture *gesture = event->gesture(Qt::PinchGesture)) {
+        QPinchGesture *pinch = static_cast<QPinchGesture *>(gesture);
+        if (pinch->changeFlags() & QPinchGesture::ScaleFactorChanged)
+            QChart::zoom(pinch->scaleFactor());
+    }
+
+    return true;
+}
+//![1]

--- a/Gui/GuiComponents/chart.h
+++ b/Gui/GuiComponents/chart.h
@@ -1,0 +1,59 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the Qt Charts module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:GPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3 or (at your option) any later version
+** approved by the KDE Free Qt Foundation. The licenses are as published by
+** the Free Software Foundation and appearing in the file LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef CHART_H
+#define CHART_H
+
+#include <QtCharts/QChart>
+
+QT_BEGIN_NAMESPACE
+class QGestureEvent;
+QT_END_NAMESPACE
+
+QT_CHARTS_USE_NAMESPACE
+
+//![1]
+class Chart : public QChart
+//![1]
+{
+public:
+    explicit Chart(QGraphicsItem *parent = 0, Qt::WindowFlags wFlags = 0);
+    ~Chart();
+
+protected:
+    bool sceneEvent(QEvent *event);
+
+private:
+    bool gestureEvent(QGestureEvent *event);
+
+private:
+
+};
+
+#endif // CHART_H

--- a/Gui/GuiComponents/chart.h
+++ b/Gui/GuiComponents/chart.h
@@ -51,9 +51,6 @@ protected:
 
 private:
     bool gestureEvent(QGestureEvent *event);
-
-private:
-
 };
 
 #endif // CHART_H

--- a/Gui/MainWindow.cpp
+++ b/Gui/MainWindow.cpp
@@ -187,6 +187,7 @@ void MainWindow::newOptimisation() {
         ConfigSimulationDialog diag(opt, this);
         if(diag.exec() == QDialog::Accepted) {
 
+            opt->setBoundaryPoints(meshDialog.boundaryPoints());
             opt->setControlPoints(meshDialog.controlPoints());
             bool success = mOptimisationModel->run(opt);
 

--- a/Gui/MainWindow.cpp
+++ b/Gui/MainWindow.cpp
@@ -128,6 +128,7 @@ void MainWindow::setLogText() {
 void MainWindow::optimisationFitnessChanged(int index) {
     if(mCurrentOptimisationIndex == index) {
         ui->fitnessPlot->updatePlot();
+        pcWindow->update();
     }
 }
 

--- a/Gui/MainWindow.cpp
+++ b/Gui/MainWindow.cpp
@@ -9,6 +9,7 @@
 #include "Mesh.h"
 #include "windowsizing.h"
 #include "ViewConfigureDialog.h"
+#include "ParallelCoordinatesWindow.h"
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
@@ -25,6 +26,9 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->actionShowCurrentOptimisationFiles, &QAction::triggered, this, &MainWindow::revealFilesCurrentOptimisation);
 
     setupGraphicsView();
+
+    pcWindow = new ParallelCoordinatesWindow(this);
+
 }
 
 void MainWindow::setSplitterSizes() {
@@ -101,6 +105,7 @@ void MainWindow::setOptimisationModel(OptimisationModel* optimisationModel) {
     mOptimisationModel = optimisationModel;
     ui->optimisationComboBox->setModel(mOptimisationModel);
     ui->fitnessPlot->setOptimisationModel(mOptimisationModel);
+    pcWindow->setOptimisationModel(optimisationModel);
     connect(ui->optimisationComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &MainWindow::setCurrentOptimisationIndex);
     connect(mOptimisationModel, &OptimisationModel::optimisationFitnessChanged, this, &MainWindow::optimisationFitnessChanged);
     connect(mOptimisationModel, &OptimisationModel::optimisationOutputChanged, this, &MainWindow::optimisationOutputChanged);
@@ -132,6 +137,9 @@ void MainWindow::setCurrentOptimisationIndex(int index) {
 
         // update fitness plot
         ui->fitnessPlot->setCurrentOptimisationIndex(index);
+
+        pcWindow->setCurrentOptimisationIndex(index);
+        openParallelCoordinatesWindow();
 
         // update log text
         setLogText();
@@ -273,4 +281,8 @@ void MainWindow::on_actionVisualSettings_triggered()
 
         ui->fitnessPlot->configureView(lineSize, pointSize);
     }
+}
+
+void MainWindow::openParallelCoordinatesWindow(){
+    pcWindow->show();
 }

--- a/Gui/MainWindow.cpp
+++ b/Gui/MainWindow.cpp
@@ -287,3 +287,8 @@ void MainWindow::on_actionVisualSettings_triggered()
 void MainWindow::openParallelCoordinatesWindow(){
     pcWindow->show();
 }
+
+void MainWindow::on_actionShow_triggered()
+{
+    openParallelCoordinatesWindow();
+}

--- a/Gui/MainWindow.h
+++ b/Gui/MainWindow.h
@@ -42,6 +42,8 @@ private slots:
 
     void on_actionVisualSettings_triggered();
 
+    void on_actionShow_triggered();
+
 private:
     void setMeshViewSimulation(int iGen, int agent);
     void setLogText();

--- a/Gui/MainWindow.h
+++ b/Gui/MainWindow.h
@@ -7,6 +7,7 @@
 #include "MeshModel.h"
 #include "OptimisationModel.h"
 #include "ProfileView.h"
+#include "ParallelCoordinatesWindow.h"
 
 namespace Ui {
 class MainWindow;
@@ -44,6 +45,13 @@ private slots:
 private:
     void setMeshViewSimulation(int iGen, int agent);
     void setLogText();
+
+    /**
+     * @brief openParallelCoordinatesWindow Opens a parallel coordinate in a new window
+     */
+    void openParallelCoordinatesWindow();
+
+
     Optimisation* currentOptimisation();
     Ui::MainWindow *ui;
     ProfileModel mProfileModel;
@@ -52,6 +60,8 @@ private:
     MeshModel* mCurrentMeshViewModel;
     ProfileView* mProfileView = nullptr;
     QString mClusterPassword="";
+
+    ParallelCoordinatesWindow* pcWindow;
 };
 
 #endif // MAINWINDOW_H

--- a/Gui/MainWindow.ui
+++ b/Gui/MainWindow.ui
@@ -388,9 +388,16 @@
     </property>
     <addaction name="actionVisualSettings"/>
    </widget>
+   <widget class="QMenu" name="menuParallel_Coordinates_Graph">
+    <property name="title">
+     <string>Parallel Coordinates Graph</string>
+    </property>
+    <addaction name="actionShow"/>
+   </widget>
    <addaction name="menuOptimisations"/>
    <addaction name="menuLog"/>
    <addaction name="menuSettings"/>
+   <addaction name="menuParallel_Coordinates_Graph"/>
   </widget>
   <action name="actionNewOptimisation">
    <property name="text">
@@ -436,6 +443,11 @@
    </property>
    <property name="toolTip">
     <string>Visual settings</string>
+   </property>
+  </action>
+  <action name="actionShow">
+   <property name="text">
+    <string>Show</string>
    </property>
   </action>
  </widget>

--- a/Gui/Plotter/qcustomplot.cpp
+++ b/Gui/Plotter/qcustomplot.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
 **                                                                        **
 **  QCustomPlot, an easy to use, modern plotting widget for Qt            **
-**  Copyright (C) 2011-2017 Emanuel Eichhammer                            **
+**  Copyright (C) 2011-2018 Emanuel Eichhammer                            **
 **                                                                        **
 **  This program is free software: you can redistribute it and/or modify  **
 **  it under the terms of the GNU General Public License as published by  **
@@ -19,15 +19,15 @@
 ****************************************************************************
 **           Author: Emanuel Eichhammer                                   **
 **  Website/Contact: http://www.qcustomplot.com/                          **
-**             Date: 04.09.17                                             **
-**          Version: 2.0.0                                                **
+**             Date: 25.06.18                                             **
+**          Version: 2.0.1                                                **
 ****************************************************************************/
 
 #include "qcustomplot.h"
 
 
 /* including file 'src/vector2d.cpp', size 7340                              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPVector2D
@@ -260,7 +260,7 @@ QCPVector2D &QCPVector2D::operator-=(const QCPVector2D &vector)
 
 
 /* including file 'src/painter.cpp', size 8670                               */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPPainter
@@ -478,7 +478,7 @@ void QCPPainter::makeNonCosmetic()
 
 
 /* including file 'src/paintbuffer.cpp', size 18502                          */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAbstractPaintBuffer
@@ -950,8 +950,8 @@ void QCPPaintBufferGlFbo::reallocateBuffer()
 /* end of 'src/paintbuffer.cpp' */
 
 
-/* including file 'src/layer.cpp', size 37064                                */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/layer.cpp', size 37304                                */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPLayer
@@ -1464,9 +1464,13 @@ bool QCPLayerable::realVisibility() const
   placed in \a details. So in the subsequent \ref selectEvent, the decision which part was
   selected doesn't have to be done a second time for a single selection operation.
   
+  In the case of 1D Plottables (\ref QCPAbstractPlottable1D, like \ref QCPGraph or \ref QCPBars) \a
+  details will be set to a \ref QCPDataSelection, describing the closest data point to \a pos.
+  
   You may pass 0 as \a details to indicate that you are not interested in those selection details.
   
-  \see selectEvent, deselectEvent, mousePressEvent, wheelEvent, QCustomPlot::setInteractions
+  \see selectEvent, deselectEvent, mousePressEvent, wheelEvent, QCustomPlot::setInteractions,
+  QCPAbstractPlottable1D::selectTestRect
 */
 double QCPLayerable::selectTest(const QPointF &pos, bool onlySelectable, QVariant *details) const
 {
@@ -1804,7 +1808,7 @@ void QCPLayerable::wheelEvent(QWheelEvent *event)
 
 
 /* including file 'src/axis/range.cpp', size 12221                           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPRange
@@ -2125,8 +2129,8 @@ bool QCPRange::validRange(const QCPRange &range)
 /* end of 'src/axis/range.cpp' */
 
 
-/* including file 'src/selection.cpp', size 21906                            */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/selection.cpp', size 21941                            */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPDataRange
@@ -2136,8 +2140,9 @@ bool QCPRange::validRange(const QCPRange &range)
   \brief Describes a data range given by begin and end index
   
   QCPDataRange holds two integers describing the begin (\ref setBegin) and end (\ref setEnd) index
-  of a contiguous set of data points. The end index points to the data point above the last data point that's part of
-  the data range, similarly to the nomenclature used in standard iterators.
+  of a contiguous set of data points. The end index points to the data point just after the last
+  data point that's part of the data range, similarly to the nomenclature used in standard
+  iterators.
   
   Data Ranges are not bound to a certain plottable, thus they can be freely exchanged, created and
   modified. If a non-contiguous data set shall be described, the class \ref QCPDataSelection is
@@ -2184,7 +2189,7 @@ bool QCPRange::validRange(const QCPRange &range)
 
 /*! \fn void QCPDataRange::setEnd(int end)
   
-  Sets the end of this data range. The \a end index points to the data point just above the last
+  Sets the end of this data range. The \a end index points to the data point just after the last
   data point that is part of the data range.
   
   No checks or corrections are made to ensure the resulting range is valid (\ref isValid).
@@ -2300,7 +2305,7 @@ bool QCPDataRange::intersects(const QCPDataRange &other) const
 }
 
 /*!
-  Returns whether all data points described by this data range are also in \a other.
+  Returns whether all data points of \a other are also contained inside this data range.
   
   \see intersects
 */
@@ -2631,7 +2636,8 @@ void QCPDataSelection::enforceType(QCP::SelectionType type)
     }
     case QCP::stDataRange:
     {
-      mDataRanges = QList<QCPDataRange>() << span();
+      if (!isEmpty())
+        mDataRanges = QList<QCPDataRange>() << span();
       break;
     }
     case QCP::stMultipleDataRanges:
@@ -2726,7 +2732,7 @@ QCPDataSelection QCPDataSelection::inverse(const QCPDataRange &outerRange) const
 
 
 /* including file 'src/selectionrect.cpp', size 9224                         */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPSelectionRect
@@ -2954,8 +2960,8 @@ void QCPSelectionRect::draw(QCPPainter *painter)
 /* end of 'src/selectionrect.cpp' */
 
 
-/* including file 'src/layout.cpp', size 79064                               */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/layout.cpp', size 79139                               */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPMarginGroup
@@ -4074,7 +4080,7 @@ QCPLayoutGrid::QCPLayoutGrid() :
   mColumnSpacing(5),
   mRowSpacing(5),
   mWrap(0),
-  mFillOrder(foRowsFirst)
+  mFillOrder(foColumnsFirst)
 {
 }
 
@@ -4350,7 +4356,8 @@ void QCPLayoutGrid::setWrap(int count)
   The specified \a order defines whether rows or columns are filled first. Using \ref setWrap, you
   can control at which row/column count wrapping into the next column/row will occur. If you set it
   to zero, no wrapping will ever occur. Changing the fill order also changes the meaning of the
-  linear index used e.g. in \ref elementAt and \ref takeAt.
+  linear index used e.g. in \ref elementAt and \ref takeAt. The default fill order for \ref
+  QCPLayoutGrid is \ref foColumnsFirst.
 
   If you want to have all current elements arranged in the new order, set \a rearrange to true. The
   elements will be rearranged in a way that tries to preserve their linear index. However, empty
@@ -5125,7 +5132,7 @@ void QCPLayoutInset::addElement(QCPLayoutElement *element, const QRectF &rect)
 
 
 /* including file 'src/lineending.cpp', size 11536                           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPLineEnding
@@ -5424,7 +5431,7 @@ void QCPLineEnding::draw(QCPPainter *painter, const QCPVector2D &pos, double ang
 
 
 /* including file 'src/axis/axisticker.cpp', size 18664                      */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisTicker
@@ -5844,7 +5851,7 @@ double QCPAxisTicker::cleanMantissa(double input) const
 
 
 /* including file 'src/axis/axistickerdatetime.cpp', size 14443              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisTickerDateTime
@@ -6141,7 +6148,7 @@ double QCPAxisTickerDateTime::dateTimeToKey(const QDate date)
 
 
 /* including file 'src/axis/axistickertime.cpp', size 11747                  */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisTickerTime
@@ -6390,7 +6397,7 @@ void QCPAxisTickerTime::replaceUnit(QString &text, QCPAxisTickerTime::TimeUnit u
 
 
 /* including file 'src/axis/axistickerfixed.cpp', size 5583                  */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisTickerFixed
@@ -6491,8 +6498,8 @@ double QCPAxisTickerFixed::getTickStep(const QCPRange &range)
 /* end of 'src/axis/axistickerfixed.cpp' */
 
 
-/* including file 'src/axis/axistickertext.cpp', size 8653                   */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/axis/axistickertext.cpp', size 8661                   */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisTickerText
@@ -6562,7 +6569,7 @@ void QCPAxisTickerText::setTicks(const QMap<double, QString> &ticks)
   
   \see addTicks, addTick, clear
 */
-void QCPAxisTickerText::setTicks(const QVector<double> &positions, const QVector<QString> labels)
+void QCPAxisTickerText::setTicks(const QVector<double> &positions, const QVector<QString> &labels)
 {
   clear();
   addTicks(positions, labels);
@@ -6600,7 +6607,7 @@ void QCPAxisTickerText::clear()
   
   \see addTicks, setTicks, clear
 */
-void QCPAxisTickerText::addTick(double position, QString label)
+void QCPAxisTickerText::addTick(double position, const QString &label)
 {
   mTicks.insert(position, label);
 }
@@ -6705,7 +6712,7 @@ QVector<double> QCPAxisTickerText::createTickVector(double tickStep, const QCPRa
 
 
 /* including file 'src/axis/axistickerpi.cpp', size 11170                    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisTickerPi
@@ -6992,7 +6999,7 @@ QString QCPAxisTickerPi::unicodeSubscript(int number) const
 
 
 /* including file 'src/axis/axistickerlog.cpp', size 7106                    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisTickerLog
@@ -7132,8 +7139,8 @@ QVector<double> QCPAxisTickerLog::createTickVector(double tickStep, const QCPRan
 /* end of 'src/axis/axistickerlog.cpp' */
 
 
-/* including file 'src/axis/axis.cpp', size 99397                            */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/axis/axis.cpp', size 99515                            */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -7653,10 +7660,14 @@ QCPLineEnding QCPAxis::upperEnding() const
 /*!
   Sets whether the axis uses a linear scale or a logarithmic scale.
   
-  Note that this method controls the coordinate transformation. You will likely also want to use a
-  logarithmic tick spacing and labeling, which can be achieved by setting an instance of \ref
-  QCPAxisTickerLog via \ref setTicker. See the documentation of \ref QCPAxisTickerLog about the
-  details of logarithmic axis tick creation.
+  Note that this method controls the coordinate transformation. For logarithmic scales, you will
+  likely also want to use a logarithmic tick spacing and labeling, which can be achieved by setting
+  the axis ticker to an instance of \ref QCPAxisTickerLog :
+  
+  \snippet documentation/doc-code-snippets/mainwindow.cpp qcpaxisticker-log-creation
+  
+  See the documentation of \ref QCPAxisTickerLog about the details of logarithmic axis tick
+  creation.
   
   \ref setNumberPrecision
 */
@@ -9819,7 +9830,7 @@ void QCPAxisPainterPrivate::getMaxTickLabelSize(const QFont &font, const QString
 
 
 /* including file 'src/scatterstyle.cpp', size 17450                         */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPScatterStyle
@@ -10293,7 +10304,7 @@ void QCPScatterStyle::drawShape(QCPPainter *painter, double x, double y) const
 //amalgamation: add datacontainer.cpp
 
 /* including file 'src/plottable.cpp', size 38845                            */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPSelectionDecorator
@@ -11265,8 +11276,8 @@ void QCPAbstractPlottable::deselectEvent(bool *selectionStateChanged)
 /* end of 'src/plottable.cpp' */
 
 
-/* including file 'src/item.cpp', size 49269                                 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/item.cpp', size 49271                                 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemAnchor
@@ -12411,7 +12422,7 @@ double QCPAbstractItem::rectDistance(const QRectF &rect, const QPointF &pos, boo
   QList<QLineF> lines;
   lines << QLineF(rect.topLeft(), rect.topRight()) << QLineF(rect.bottomLeft(), rect.bottomRight())
         << QLineF(rect.topLeft(), rect.bottomLeft()) << QLineF(rect.topRight(), rect.bottomRight());
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   for (int i=0; i<lines.size(); ++i)
   {
     double distSqr = QCPVector2D(pos).distanceSquaredToLine(lines.at(i).p1(), lines.at(i).p2());
@@ -12536,8 +12547,8 @@ QCP::Interaction QCPAbstractItem::selectionCategory() const
 /* end of 'src/item.cpp' */
 
 
-/* including file 'src/core.cpp', size 125037                                */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/core.cpp', size 126207                                */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCustomPlot
@@ -14189,7 +14200,17 @@ int QCustomPlot::axisRectCount() const
   added, all of them may be accessed with this function in a linear fashion (even when they are
   nested in a layout hierarchy or inside other axis rects via QCPAxisRect::insetLayout).
   
-  \see axisRectCount, axisRects
+  The order of the axis rects is given by the fill order of the \ref QCPLayout that is holding
+  them. For example, if the axis rects are in the top level grid layout (accessible via \ref
+  QCustomPlot::plotLayout), they are ordered from left to right, top to bottom, if the layout's
+  default \ref QCPLayoutGrid::setFillOrder "setFillOrder" of \ref QCPLayoutGrid::foColumnsFirst
+  "foColumnsFirst" wasn't changed.
+  
+  If you want to access axis rects by their row and column index, use the layout interface. For
+  example, use \ref QCPLayoutGrid::element of the top level grid layout, and \c qobject_cast the
+  returned layout element to \ref QCPAxisRect. (See also \ref thelayoutsystem.)
+  
+  \see axisRectCount, axisRects, QCPLayoutGrid::setFillOrder
 */
 QCPAxisRect *QCustomPlot::axisRect(int index) const
 {
@@ -14207,7 +14228,13 @@ QCPAxisRect *QCustomPlot::axisRect(int index) const
 /*!
   Returns all axis rects in the plot.
   
-  \see axisRectCount, axisRect
+  The order of the axis rects is given by the fill order of the \ref QCPLayout that is holding
+  them. For example, if the axis rects are in the top level grid layout (accessible via \ref
+  QCustomPlot::plotLayout), they are ordered from left to right, top to bottom, if the layout's
+  default \ref QCPLayoutGrid::setFillOrder "setFillOrder" of \ref QCPLayoutGrid::foColumnsFirst
+  "foColumnsFirst" wasn't changed.
+  
+  \see axisRectCount, axisRect, QCPLayoutGrid::setFillOrder
 */
 QList<QCPAxisRect*> QCustomPlot::axisRects() const
 {
@@ -15718,8 +15745,8 @@ void QCustomPlot::toPainter(QCPPainter *painter, int width, int height)
 
 //amalgamation: add plottable1d.cpp
 
-/* including file 'src/colorgradient.cpp', size 24646                        */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/colorgradient.cpp', size 25342                        */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -16282,10 +16309,22 @@ void QCPColorGradient::updateColorBuffer()
       QMap<double, QColor>::const_iterator it = mColorStops.lowerBound(position);
       if (it == mColorStops.constEnd()) // position is on or after last stop, use color of last stop
       {
-        mColorBuffer[i] = (it-1).value().rgba();
+        if (useAlpha)
+        {
+          const QColor col = (it-1).value();
+          const float alphaPremultiplier = col.alpha()/255.0f; // since we use QImage::Format_ARGB32_Premultiplied
+          mColorBuffer[i] = qRgba(col.red()*alphaPremultiplier, col.green()*alphaPremultiplier, col.blue()*alphaPremultiplier, col.alpha());
+        } else
+          mColorBuffer[i] = (it-1).value().rgba();
       } else if (it == mColorStops.constBegin()) // position is on or before first stop, use color of first stop
       {
-        mColorBuffer[i] = it.value().rgba();
+        if (useAlpha)
+        {
+          const QColor col = it.value();
+          const float alphaPremultiplier = col.alpha()/255.0f; // since we use QImage::Format_ARGB32_Premultiplied
+          mColorBuffer[i] = qRgba(col.red()*alphaPremultiplier, col.green()*alphaPremultiplier, col.blue()*alphaPremultiplier, col.alpha());
+        } else
+          mColorBuffer[i] = it.value().rgba();
       } else // position is in between stops (or on an intermediate stop), interpolate color
       {
         QMap<double, QColor>::const_iterator high = it;
@@ -16359,7 +16398,7 @@ void QCPColorGradient::updateColorBuffer()
 
 
 /* including file 'src/selectiondecorator-bracket.cpp', size 12313           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPSelectionDecoratorBracket
@@ -16645,7 +16684,7 @@ QPointF QCPSelectionDecoratorBracket::getPixelCoordinates(const QCPPlottableInte
 
 
 /* including file 'src/layoutelements/layoutelement-axisrect.cpp', size 47584 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200  */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200  */
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -17919,8 +17958,8 @@ void QCPAxisRect::wheelEvent(QWheelEvent *event)
 /* end of 'src/layoutelements/layoutelement-axisrect.cpp' */
 
 
-/* including file 'src/layoutelements/layoutelement-legend.cpp', size 31097  */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/layoutelements/layoutelement-legend.cpp', size 31153  */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAbstractLegendItem
@@ -18259,7 +18298,7 @@ QSize QCPPlottableLegendItem::minimumOuterSizeHint() const
 
   Use the methods \ref setFillOrder and \ref setWrap inherited from \ref QCPLayoutGrid to control
   in which order (column first or row first) the legend is filled up when calling \ref addItem, and
-  at which column or row wrapping occurs.
+  at which column or row wrapping occurs. The default fill order for legends is \ref foRowsFirst.
 
   By default, every QCustomPlot has one legend (\ref QCustomPlot::legend) which is placed in the
   inset layout of the main axis rect (\ref QCPAxisRect::insetLayout). To move the legend to another
@@ -18836,7 +18875,7 @@ void QCPLegend::parentPlotInitialized(QCustomPlot *parentPlot)
 
 
 /* including file 'src/layoutelements/layoutelement-textelement.cpp', size 12761 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200     */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200     */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPTextElement
@@ -19239,8 +19278,8 @@ QColor QCPTextElement::mainTextColor() const
 /* end of 'src/layoutelements/layoutelement-textelement.cpp' */
 
 
-/* including file 'src/layoutelements/layoutelement-colorscale.cpp', size 25770 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200    */
+/* including file 'src/layoutelements/layoutelement-colorscale.cpp', size 26246 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200    */
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -19459,12 +19498,21 @@ void QCPColorScale::setDataRange(const QCPRange &dataRange)
 }
 
 /*!
-  Sets the scale type of the color scale, i.e. whether values are linearly associated with colors
+  Sets the scale type of the color scale, i.e. whether values are associated with colors linearly
   or logarithmically.
   
   It is equivalent to calling QCPColorMap::setDataScaleType on any of the connected color maps. It is
   also equivalent to directly accessing the \ref axis and setting its scale type with \ref
   QCPAxis::setScaleType.
+  
+  Note that this method controls the coordinate transformation. For logarithmic scales, you will
+  likely also want to use a logarithmic tick spacing and labeling, which can be achieved by setting
+  the color scale's \ref axis ticker to an instance of \ref QCPAxisTickerLog :
+  
+  \snippet documentation/doc-code-snippets/mainwindow.cpp qcpaxisticker-log-colorscale
+  
+  See the documentation of \ref QCPAxisTickerLog about the details of logarithmic axis tick
+  creation.
   
   \see setDataRange, setGradient
 */
@@ -19899,8 +19947,8 @@ void QCPColorScaleAxisRectPrivate::axisSelectableChanged(QCPAxis::SelectablePart
 /* end of 'src/layoutelements/layoutelement-colorscale.cpp' */
 
 
-/* including file 'src/plottables/plottable-graph.cpp', size 73960           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottables/plottable-graph.cpp', size 74194           */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPGraphData
@@ -20259,7 +20307,14 @@ void QCPGraph::addData(double key, double value)
   mDataContainer->add(QCPGraphData(key, value));
 }
 
-/* inherits documentation from base class */
+/*!
+  Implements a selectTest specific to this plottable's point geometry.
+
+  If \a details is not 0, it will be set to a \ref QCPDataSelection, describing the closest data
+  point to \a pos.
+  
+  \seebaseclassmethod \ref QCPAbstractPlottable::selectTest
+*/
 double QCPGraph::selectTest(const QPointF &pos, bool onlySelectable, QVariant *details) const
 {
   if ((onlySelectable && mSelectable == QCP::stNone) || mDataContainer->isEmpty())
@@ -20857,11 +20912,11 @@ void QCPGraph::getOptimizedLineData(QVector<QCPGraphData> *lineData, const QCPGr
   if (begin == end) return;
   
   int dataCount = end-begin;
-  int maxCount = std::numeric_limits<int>::max();
+  int maxCount = (std::numeric_limits<int>::max)();
   if (mAdaptiveSampling)
   {
     double keyPixelSpan = qAbs(keyAxis->coordToPixel(begin->key)-keyAxis->coordToPixel((end-1)->key));
-    if (2*keyPixelSpan+2 < (double)std::numeric_limits<int>::max())
+    if (2*keyPixelSpan+2 < static_cast<double>((std::numeric_limits<int>::max)()))
       maxCount = 2*keyPixelSpan+2;
   }
   
@@ -20958,7 +21013,7 @@ void QCPGraph::getOptimizedScatterData(QVector<QCPGraphData> *scatterData, QCPGr
   }
   if (begin == end) return;
   int dataCount = end-begin;
-  int maxCount = std::numeric_limits<int>::max();
+  int maxCount = (std::numeric_limits<int>::max)();
   if (mAdaptiveSampling)
   {
     int keyPixelSpan = qAbs(keyAxis->coordToPixel(begin->key)-keyAxis->coordToPixel((end-1)->key));
@@ -21583,7 +21638,7 @@ double QCPGraph::pointDistance(const QPointF &pixelPoint, QCPGraphDataContainer:
     return -1.0;
   
   // calculate minimum distances to graph data points and find closestData iterator:
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   // determine which key range comes into question, taking selection tolerance around pos into account:
   double posKeyMin, posKeyMax, dummy;
   pixelsToCoords(pixelPoint-QPointF(mParentPlot->selectionTolerance(), mParentPlot->selectionTolerance()), posKeyMin, dummy);
@@ -21647,8 +21702,8 @@ int QCPGraph::findIndexBelowY(const QVector<QPointF> *data, double y) const
 /* end of 'src/plottables/plottable-graph.cpp' */
 
 
-/* including file 'src/plottables/plottable-curve.cpp', size 63527           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottables/plottable-curve.cpp', size 63742           */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPCurveData
@@ -22014,7 +22069,14 @@ void QCPCurve::addData(double key, double value)
     mDataContainer->add(QCPCurveData(0.0, key, value));
 }
 
-/* inherits documentation from base class */
+/*!
+  Implements a selectTest specific to this plottable's point geometry.
+
+  If \a details is not 0, it will be set to a \ref QCPDataSelection, describing the closest data
+  point to \a pos.
+  
+  \seebaseclassmethod \ref QCPAbstractPlottable::selectTest
+*/
 double QCPCurve::selectTest(const QPointF &pos, bool onlySelectable, QVariant *details) const
 {
   if ((onlySelectable && mSelectable == QCP::stNone) || mDataContainer->isEmpty())
@@ -23064,7 +23126,7 @@ double QCPCurve::pointDistance(const QPointF &pixelPoint, QCPCurveDataContainer:
   }
   
   // calculate minimum distances to curve data points and find closestData iterator:
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   // iterate over found data points and then choose the one with the shortest distance to pos:
   QCPCurveDataContainer::const_iterator begin = mDataContainer->constBegin();
   QCPCurveDataContainer::const_iterator end = mDataContainer->constEnd();
@@ -23096,8 +23158,8 @@ double QCPCurve::pointDistance(const QPointF &pixelPoint, QCPCurveDataContainer:
 /* end of 'src/plottables/plottable-curve.cpp' */
 
 
-/* including file 'src/plottables/plottable-bars.cpp', size 43512            */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottables/plottable-bars.cpp', size 43725            */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -23844,7 +23906,14 @@ QCPDataSelection QCPBars::selectTestRect(const QRectF &rect, bool onlySelectable
   return result;
 }
 
-/* inherits documentation from base class */
+/*!
+  Implements a selectTest specific to this plottable's point geometry.
+
+  If \a details is not 0, it will be set to a \ref QCPDataSelection, describing the closest data
+  point to \a pos.
+  
+  \seebaseclassmethod \ref QCPAbstractPlottable::selectTest
+*/
 double QCPBars::selectTest(const QPointF &pos, bool onlySelectable, QVariant *details) const
 {
   Q_UNUSED(details)
@@ -24264,8 +24333,8 @@ void QCPBars::connectBars(QCPBars *lower, QCPBars *upper)
 /* end of 'src/plottables/plottable-bars.cpp' */
 
 
-/* including file 'src/plottables/plottable-statisticalbox.cpp', size 28622  */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottables/plottable-statisticalbox.cpp', size 28837  */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPStatisticalBoxData
@@ -24669,7 +24738,14 @@ QCPDataSelection QCPStatisticalBox::selectTestRect(const QRectF &rect, bool only
   return result;
 }
 
-/* inherits documentation from base class */
+/*!
+  Implements a selectTest specific to this plottable's point geometry.
+
+  If \a details is not 0, it will be set to a \ref QCPDataSelection, describing the closest data
+  point to \a pos.
+  
+  \seebaseclassmethod \ref QCPAbstractPlottable::selectTest
+*/
 double QCPStatisticalBox::selectTest(const QPointF &pos, bool onlySelectable, QVariant *details) const
 {
   Q_UNUSED(details)
@@ -24684,7 +24760,7 @@ double QCPStatisticalBox::selectTest(const QPointF &pos, bool onlySelectable, QV
     QCPStatisticalBoxDataContainer::const_iterator visibleBegin, visibleEnd;
     QCPStatisticalBoxDataContainer::const_iterator closestDataPoint = mDataContainer->constEnd();
     getVisibleDataBounds(visibleBegin, visibleEnd);
-    double minDistSqr = std::numeric_limits<double>::max();
+    double minDistSqr = (std::numeric_limits<double>::max)();
     for (QCPStatisticalBoxDataContainer::const_iterator it=visibleBegin; it!=visibleEnd; ++it)
     {
       if (getQuartileBox(it).contains(pos)) // quartile box
@@ -24919,7 +24995,7 @@ QVector<QLineF> QCPStatisticalBox::getWhiskerBarLines(QCPStatisticalBoxDataConta
 
 
 /* including file 'src/plottables/plottable-colormap.cpp', size 47881        */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPColorMapData
@@ -26053,8 +26129,8 @@ void QCPColorMap::drawLegendIcon(QCPPainter *painter, const QRectF &rect) const
 /* end of 'src/plottables/plottable-colormap.cpp' */
 
 
-/* including file 'src/plottables/plottable-financial.cpp', size 42610       */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottables/plottable-financial.cpp', size 42827       */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPFinancialData
@@ -26459,7 +26535,14 @@ QCPDataSelection QCPFinancial::selectTestRect(const QRectF &rect, bool onlySelec
   return result;
 }
 
-/* inherits documentation from base class */
+/*!
+  Implements a selectTest specific to this plottable's point geometry.
+
+  If \a details is not 0, it will be set to a \ref QCPDataSelection, describing the closest data
+  point to \a pos.
+  
+  \seebaseclassmethod \ref QCPAbstractPlottable::selectTest
+*/
 double QCPFinancial::selectTest(const QPointF &pos, bool onlySelectable, QVariant *details) const
 {
   Q_UNUSED(details)
@@ -26852,7 +26935,7 @@ double QCPFinancial::ohlcSelectTest(const QPointF &pos, const QCPFinancialDataCo
   QCPAxis *valueAxis = mValueAxis.data();
   if (!keyAxis || !valueAxis) { qDebug() << Q_FUNC_INFO << "invalid key or value axis"; return -1; }
 
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   if (keyAxis->orientation() == Qt::Horizontal)
   {
     for (QCPFinancialDataContainer::const_iterator it=begin; it!=end; ++it)
@@ -26899,7 +26982,7 @@ double QCPFinancial::candlestickSelectTest(const QPointF &pos, const QCPFinancia
   QCPAxis *valueAxis = mValueAxis.data();
   if (!keyAxis || !valueAxis) { qDebug() << Q_FUNC_INFO << "invalid key or value axis"; return -1; }
 
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   if (keyAxis->orientation() == Qt::Horizontal)
   {
     for (QCPFinancialDataContainer::const_iterator it=begin; it!=end; ++it)
@@ -27008,8 +27091,8 @@ QRectF QCPFinancial::selectionHitBox(QCPFinancialDataContainer::const_iterator i
 /* end of 'src/plottables/plottable-financial.cpp' */
 
 
-/* including file 'src/plottables/plottable-errorbar.cpp', size 37355        */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottables/plottable-errorbar.cpp', size 37570        */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPErrorBarsData
@@ -27451,7 +27534,14 @@ int QCPErrorBars::findEnd(double sortKey, bool expandedRange) const
   return 0;
 }
 
-/* inherits documentation from base class */
+/*!
+  Implements a selectTest specific to this plottable's point geometry.
+
+  If \a details is not 0, it will be set to a \ref QCPDataSelection, describing the closest data
+  point to \a pos.
+  
+  \seebaseclassmethod \ref QCPAbstractPlottable::selectTest
+*/
 double QCPErrorBars::selectTest(const QPointF &pos, bool onlySelectable, QVariant *details) const
 {
   if (!mDataPlottable) return -1;
@@ -27870,7 +27960,7 @@ double QCPErrorBars::pointDistance(const QPointF &pixelPoint, QCPErrorBarsDataCo
   getVisibleDataBounds(begin, end, QCPDataRange(0, dataCount()));
   
   // calculate minimum distances to error backbones (whiskers are ignored for speed) and find closestData iterator:
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   QVector<QLineF> backbones, whiskers;
   for (QCPErrorBarsDataContainer::const_iterator it=begin; it!=end; ++it)
   {
@@ -27970,7 +28060,7 @@ bool QCPErrorBars::rectIntersectsLine(const QRectF &pixelRect, const QLineF &lin
 
 
 /* including file 'src/items/item-straightline.cpp', size 7592               */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemStraightLine
@@ -28151,7 +28241,7 @@ QPen QCPItemStraightLine::mainPen() const
 
 
 /* including file 'src/items/item-line.cpp', size 8498                       */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemLine
@@ -28381,8 +28471,8 @@ QPen QCPItemLine::mainPen() const
 /* end of 'src/items/item-line.cpp' */
 
 
-/* including file 'src/items/item-curve.cpp', size 7159                      */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/items/item-curve.cpp', size 7248                      */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemCurve
@@ -28492,9 +28582,12 @@ double QCPItemCurve::selectTest(const QPointF &pos, bool onlySelectable, QVarian
   QPainterPath cubicPath(startVec);
   cubicPath.cubicTo(startDirVec, endDirVec, endVec);
   
-  QPolygonF polygon = cubicPath.toSubpathPolygons().first();
+  QList<QPolygonF> polygons = cubicPath.toSubpathPolygons();
+  if (polygons.isEmpty())
+    return -1;
+  const QPolygonF polygon = polygons.first();
   QCPVector2D p(pos);
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   for (int i=1; i<polygon.size(); ++i)
   {
     double distSqr = p.distanceSquaredToLine(polygon.at(i-1), polygon.at(i));
@@ -28547,7 +28640,7 @@ QPen QCPItemCurve::mainPen() const
 
 
 /* including file 'src/items/item-rect.cpp', size 6479                       */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemRect
@@ -28704,7 +28797,7 @@ QBrush QCPItemRect::mainBrush() const
 
 
 /* including file 'src/items/item-text.cpp', size 13338                      */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemText
@@ -29052,7 +29145,7 @@ QBrush QCPItemText::mainBrush() const
 
 
 /* including file 'src/items/item-ellipse.cpp', size 7863                    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemEllipse
@@ -29240,7 +29333,7 @@ QBrush QCPItemEllipse::mainBrush() const
 
 
 /* including file 'src/items/item-pixmap.cpp', size 10615                    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemPixmap
@@ -29510,7 +29603,7 @@ QPen QCPItemPixmap::mainPen() const
 
 
 /* including file 'src/items/item-tracer.cpp', size 14624                    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemTracer
@@ -29880,7 +29973,7 @@ QBrush QCPItemTracer::mainBrush() const
 
 
 /* including file 'src/items/item-bracket.cpp', size 10687                   */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemBracket

--- a/Gui/Plotter/qcustomplot.h
+++ b/Gui/Plotter/qcustomplot.h
@@ -1,7 +1,7 @@
 /***************************************************************************
 **                                                                        **
 **  QCustomPlot, an easy to use, modern plotting widget for Qt            **
-**  Copyright (C) 2011-2017 Emanuel Eichhammer                            **
+**  Copyright (C) 2011-2018 Emanuel Eichhammer                            **
 **                                                                        **
 **  This program is free software: you can redistribute it and/or modify  **
 **  it under the terms of the GNU General Public License as published by  **
@@ -19,8 +19,8 @@
 ****************************************************************************
 **           Author: Emanuel Eichhammer                                   **
 **  Website/Contact: http://www.qcustomplot.com/                          **
-**             Date: 04.09.17                                             **
-**          Version: 2.0.0                                                **
+**             Date: 25.06.18                                             **
+**          Version: 2.0.1                                                **
 ****************************************************************************/
 
 #ifndef QCUSTOMPLOT_H
@@ -112,11 +112,16 @@ class QCPColorMap;
 class QCPColorScale;
 class QCPBars;
 
-/* including file 'src/global.h', size 16225                                 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/global.h', size 16357                                 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
+
+#define QCUSTOMPLOT_VERSION_STR "2.0.1"
+#define QCUSTOMPLOT_VERSION 0x020001
 
 // decl definitions for shared library compilation/usage:
-#if defined(QCUSTOMPLOT_COMPILE_LIBRARY)
+#if defined(QT_STATIC_BUILD)
+#  define QCP_LIB_DECL
+#elif defined(QCUSTOMPLOT_COMPILE_LIBRARY)
 #  define QCP_LIB_DECL Q_DECL_EXPORT
 #elif defined(QCUSTOMPLOT_USE_LIBRARY)
 #  define QCP_LIB_DECL Q_DECL_IMPORT
@@ -377,7 +382,7 @@ Q_DECLARE_METATYPE(QCP::SelectionType)
 
 
 /* including file 'src/vector2d.h', size 4928                                */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPVector2D
 {
@@ -451,7 +456,7 @@ inline QDebug operator<< (QDebug d, const QCPVector2D &vec)
 
 
 /* including file 'src/painter.h', size 4035                                 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPPainter : public QPainter
 {
@@ -510,7 +515,7 @@ Q_DECLARE_METATYPE(QCPPainter::PainterMode)
 
 
 /* including file 'src/paintbuffer.h', size 4958                             */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAbstractPaintBuffer
 {
@@ -618,7 +623,7 @@ protected:
 
 
 /* including file 'src/layer.h', size 6885                                   */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPLayer : public QObject
 {
@@ -767,7 +772,7 @@ private:
 
 
 /* including file 'src/axis/range.h', size 5280                              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPRange
 {
@@ -884,8 +889,8 @@ inline const QCPRange operator/(const QCPRange& range, double value)
 /* end of 'src/axis/range.h' */
 
 
-/* including file 'src/selection.h', size 8579                               */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/selection.h', size 8569                               */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPDataRange
 {
@@ -1062,8 +1067,8 @@ inline const QCPDataSelection operator-(const QCPDataRange& a, const QCPDataRang
 */
 inline QDebug operator<< (QDebug d, const QCPDataRange &dataRange)
 {
-    d.nospace() << "[" << dataRange.begin() << ".." << dataRange.end()-1 << "]";
-    return d.space();
+  d.nospace() << "QCPDataRange(" << dataRange.begin() << ", " << dataRange.end() << ")";
+  return d;
 }
 
 /*! \relates QCPDataSelection
@@ -1080,7 +1085,7 @@ inline QDebug operator<< (QDebug d, const QCPDataSelection &selection)
       d << selection.dataRange(i);
     }
     d << ")";
-    return d.space();
+    return d;
 }
 
 
@@ -1089,7 +1094,7 @@ inline QDebug operator<< (QDebug d, const QCPDataSelection &selection)
 
 
 /* including file 'src/selectionrect.h', size 3338                           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPSelectionRect : public QCPLayerable
 {
@@ -1143,7 +1148,7 @@ protected:
 
 
 /* including file 'src/layout.h', size 14224                                 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPMarginGroup : public QObject
 {
@@ -1464,7 +1469,7 @@ Q_DECLARE_METATYPE(QCPLayoutInset::InsetPlacement)
 
 
 /* including file 'src/lineending.h', size 4426                              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPLineEnding
 {
@@ -1527,8 +1532,8 @@ Q_DECLARE_METATYPE(QCPLineEnding::EndingStyle)
 /* end of 'src/lineending.h' */
 
 
-/* including file 'src/axis/axisticker.h', size 4177                         */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/axis/axisticker.h', size 4224                         */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisTicker
 {
@@ -1581,6 +1586,10 @@ protected:
   double pickClosest(double target, const QVector<double> &candidates) const;
   double getMantissa(double input, double *magnitude=0) const;
   double cleanMantissa(double input) const;
+  
+private:
+  Q_DISABLE_COPY(QCPAxisTicker)
+  
 };
 Q_DECLARE_METATYPE(QCPAxisTicker::TickStepStrategy)
 Q_DECLARE_METATYPE(QSharedPointer<QCPAxisTicker>)
@@ -1589,7 +1598,7 @@ Q_DECLARE_METATYPE(QSharedPointer<QCPAxisTicker>)
 
 
 /* including file 'src/axis/axistickerdatetime.h', size 3289                 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisTickerDateTime : public QCPAxisTicker
 {
@@ -1630,7 +1639,7 @@ protected:
 
 
 /* including file 'src/axis/axistickertime.h', size 3542                     */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisTickerTime : public QCPAxisTicker
 {
@@ -1682,7 +1691,7 @@ Q_DECLARE_METATYPE(QCPAxisTickerTime::TimeUnit)
 
 
 /* including file 'src/axis/axistickerfixed.h', size 3308                    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisTickerFixed : public QCPAxisTicker
 {
@@ -1723,8 +1732,8 @@ Q_DECLARE_METATYPE(QCPAxisTickerFixed::ScaleStrategy)
 /* end of 'src/axis/axistickerfixed.h' */
 
 
-/* including file 'src/axis/axistickertext.h', size 3085                     */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/axis/axistickertext.h', size 3090                     */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisTickerText : public QCPAxisTicker
 {
@@ -1737,12 +1746,12 @@ public:
   
   // setters:
   void setTicks(const QMap<double, QString> &ticks);
-  void setTicks(const QVector<double> &positions, const QVector<QString> labels);
+  void setTicks(const QVector<double> &positions, const QVector<QString> &labels);
   void setSubTickCount(int subTicks);
   
   // non-virtual methods:
   void clear();
-  void addTick(double position, QString label);
+  void addTick(double position, const QString &label);
   void addTicks(const QMap<double, QString> &ticks);
   void addTicks(const QVector<double> &positions, const QVector<QString> &labels);
   
@@ -1756,14 +1765,13 @@ protected:
   virtual int getSubTickCount(double tickStep) Q_DECL_OVERRIDE;
   virtual QString getTickLabel(double tick, const QLocale &locale, QChar formatChar, int precision) Q_DECL_OVERRIDE;
   virtual QVector<double> createTickVector(double tickStep, const QCPRange &range) Q_DECL_OVERRIDE;
-  
 };
 
 /* end of 'src/axis/axistickertext.h' */
 
 
 /* including file 'src/axis/axistickerpi.h', size 3911                       */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisTickerPi : public QCPAxisTicker
 {
@@ -1822,7 +1830,7 @@ Q_DECLARE_METATYPE(QCPAxisTickerPi::FractionStyle)
 
 
 /* including file 'src/axis/axistickerlog.h', size 2663                      */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisTickerLog : public QCPAxisTicker
 {
@@ -1854,8 +1862,8 @@ protected:
 /* end of 'src/axis/axistickerlog.h' */
 
 
-/* including file 'src/axis/axis.h', size 20634                              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/axis/axis.h', size 20698                              */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPGrid :public QCPLayerable
 {
@@ -2183,10 +2191,10 @@ protected:
   virtual void selectEvent(QMouseEvent *event, bool additive, const QVariant &details, bool *selectionStateChanged) Q_DECL_OVERRIDE;
   virtual void deselectEvent(bool *selectionStateChanged) Q_DECL_OVERRIDE;
   // mouse events:
-  virtual void mousePressEvent(QMouseEvent *event, const QVariant &details);
-  virtual void mouseMoveEvent(QMouseEvent *event, const QPointF &startPos);
-  virtual void mouseReleaseEvent(QMouseEvent *event, const QPointF &startPos);
-  virtual void wheelEvent(QWheelEvent *event);
+  virtual void mousePressEvent(QMouseEvent *event, const QVariant &details) Q_DECL_OVERRIDE;
+  virtual void mouseMoveEvent(QMouseEvent *event, const QPointF &startPos) Q_DECL_OVERRIDE;
+  virtual void mouseReleaseEvent(QMouseEvent *event, const QPointF &startPos) Q_DECL_OVERRIDE;
+  virtual void wheelEvent(QWheelEvent *event) Q_DECL_OVERRIDE;
   
   // non-virtual methods:
   void setupTickVectors();
@@ -2283,7 +2291,7 @@ protected:
 
 
 /* including file 'src/scatterstyle.h', size 7275                            */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPScatterStyle
 {
@@ -2390,7 +2398,7 @@ Q_DECLARE_METATYPE(QCPScatterStyle::ScatterShape)
 
 
 /* including file 'src/datacontainer.h', size 4596                           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 /*! \relates QCPDataContainer
   Returns whether the sort key of \a a is less than the sort key of \a b.
@@ -2460,7 +2468,7 @@ protected:
 // include implementation in header since it is a class template:
 
 /* including file 'src/datacontainer.cpp', size 31349                        */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPDataContainer
@@ -3234,8 +3242,8 @@ void QCPDataContainer<DataType>::performAutoSqueeze()
 /* end of 'src/datacontainer.h' */
 
 
-/* including file 'src/plottable.h', size 8312                               */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottable.h', size 8433                               */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPSelectionDecorator
 {
@@ -3329,7 +3337,7 @@ public:
   void setSelectionDecorator(QCPSelectionDecorator *decorator);
 
   // introduced virtual methods:
-  virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const = 0;
+  virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE = 0; // actually introduced in QCPLayerable as non-pure, but we want to force reimplementation for plottables
   virtual QCPPlottableInterface1D *interface1D() { return 0; }
   virtual QCPRange getKeyRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth) const = 0;
   virtual QCPRange getValueRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth, const QCPRange &inKeyRange=QCPRange()) const = 0;
@@ -3392,7 +3400,7 @@ private:
 
 
 /* including file 'src/item.h', size 9384                                    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemAnchor
 {
@@ -3577,7 +3585,7 @@ private:
 
 
 /* including file 'src/core.h', size 14886                                   */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCustomPlot : public QWidget
 {
@@ -3845,7 +3853,7 @@ Q_DECLARE_METATYPE(QCustomPlot::RefreshPriority)
 
 
 /* including file 'src/plottable1d.h', size 4544                             */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCPPlottableInterface1D
 {
@@ -3904,8 +3912,8 @@ private:
 
 // include implementation in header since it is a class template:
 
-/* including file 'src/plottable1d.cpp', size 22240                          */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottable1d.cpp', size 22361                          */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPPlottableInterface1D
@@ -4279,6 +4287,9 @@ int QCPAbstractPlottable1D<DataType>::findEnd(double sortKey, bool expandedRange
   point-like. Most subclasses will want to reimplement this method again, to provide a more
   accurate hit test based on the true data visualization geometry.
 
+  If \a details is not 0, it will be set to a \ref QCPDataSelection, describing the closest data point
+  to \a pos.
+  
   \seebaseclassmethod
 */
 template <class DataType>
@@ -4290,7 +4301,7 @@ double QCPAbstractPlottable1D<DataType>::selectTest(const QPointF &pos, bool onl
     return -1;
   
   QCPDataSelection selectionResult;
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   int minDistIndex = mDataContainer->size();
   
   typename QCPDataContainer<DataType>::const_iterator begin = mDataContainer->constBegin();
@@ -4425,7 +4436,7 @@ void QCPAbstractPlottable1D<DataType>::drawPolyline(QCPPainter *painter, const Q
 
 
 /* including file 'src/colorgradient.h', size 6243                           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPColorGradient
 {
@@ -4508,7 +4519,7 @@ Q_DECLARE_METATYPE(QCPColorGradient::GradientPreset)
 
 
 /* including file 'src/selectiondecorator-bracket.h', size 4442              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPSelectionDecoratorBracket : public QCPSelectionDecorator
 {
@@ -4577,7 +4588,7 @@ Q_DECLARE_METATYPE(QCPSelectionDecoratorBracket::BracketStyle)
 
 
 /* including file 'src/layoutelements/layoutelement-axisrect.h', size 7507   */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisRect : public QCPLayoutElement
 {
@@ -4703,7 +4714,7 @@ private:
 
 
 /* including file 'src/layoutelements/layoutelement-legend.h', size 10397    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAbstractLegendItem : public QCPLayoutElement
 {
@@ -4921,7 +4932,7 @@ Q_DECLARE_METATYPE(QCPLegend::SelectablePart)
 
 
 /* including file 'src/layoutelements/layoutelement-textelement.h', size 5353 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200  */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200  */
 
 class QCP_LIB_DECL QCPTextElement : public QCPLayoutElement
 {
@@ -5008,7 +5019,7 @@ private:
 
 
 /* including file 'src/layoutelements/layoutelement-colorscale.h', size 5923 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 
 class QCPColorScaleAxisRectPrivate : public QCPAxisRect
@@ -5116,7 +5127,7 @@ private:
 
 
 /* including file 'src/plottables/plottable-graph.h', size 9294              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPGraphData
 {
@@ -5255,7 +5266,7 @@ Q_DECLARE_METATYPE(QCPGraph::LineStyle)
 
 
 /* including file 'src/plottables/plottable-curve.h', size 7409              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPCurveData
 {
@@ -5369,8 +5380,8 @@ Q_DECLARE_METATYPE(QCPCurve::LineStyle)
 /* end of 'src/plottables/plottable-curve.h' */
 
 
-/* including file 'src/plottables/plottable-bars.h', size 8924               */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottables/plottable-bars.h', size 8933               */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPBarsGroup : public QObject
 {
@@ -5392,7 +5403,7 @@ public:
                    };
   Q_ENUMS(SpacingType)
   
-  QCPBarsGroup(QCustomPlot *parentPlot);
+  explicit QCPBarsGroup(QCustomPlot *parentPlot);
   virtual ~QCPBarsGroup();
   
   // getters:
@@ -5558,7 +5569,7 @@ Q_DECLARE_METATYPE(QCPBars::WidthType)
 
 
 /* including file 'src/plottables/plottable-statisticalbox.h', size 7516     */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPStatisticalBoxData
 {
@@ -5675,7 +5686,7 @@ protected:
 
 
 /* including file 'src/plottables/plottable-colormap.h', size 7070           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPColorMapData
 {
@@ -5811,7 +5822,7 @@ protected:
 
 
 /* including file 'src/plottables/plottable-financial.h', size 8622          */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPFinancialData
 {
@@ -5950,7 +5961,7 @@ Q_DECLARE_METATYPE(QCPFinancial::ChartStyle)
 
 
 /* including file 'src/plottables/plottable-errorbar.h', size 7727           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPErrorBarsData
 {
@@ -6075,7 +6086,7 @@ protected:
 
 
 /* including file 'src/items/item-straightline.h', size 3117                 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemStraightLine : public QCPAbstractItem
 {
@@ -6118,7 +6129,7 @@ protected:
 
 
 /* including file 'src/items/item-line.h', size 3407                         */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemLine : public QCPAbstractItem
 {
@@ -6168,7 +6179,7 @@ protected:
 
 
 /* including file 'src/items/item-curve.h', size 3379                        */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemCurve : public QCPAbstractItem
 {
@@ -6219,7 +6230,7 @@ protected:
 
 
 /* including file 'src/items/item-rect.h', size 3688                         */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemRect : public QCPAbstractItem
 {
@@ -6278,7 +6289,7 @@ protected:
 
 
 /* including file 'src/items/item-text.h', size 5554                         */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemText : public QCPAbstractItem
 {
@@ -6375,7 +6386,7 @@ protected:
 
 
 /* including file 'src/items/item-ellipse.h', size 3868                      */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemEllipse : public QCPAbstractItem
 {
@@ -6437,7 +6448,7 @@ protected:
 
 
 /* including file 'src/items/item-pixmap.h', size 4373                       */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemPixmap : public QCPAbstractItem
 {
@@ -6506,7 +6517,7 @@ protected:
 
 
 /* including file 'src/items/item-tracer.h', size 4762                       */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemTracer : public QCPAbstractItem
 {
@@ -6592,7 +6603,7 @@ Q_DECLARE_METATYPE(QCPItemTracer::TracerStyle)
 
 
 /* including file 'src/items/item-bracket.h', size 3969                      */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemBracket : public QCPAbstractItem
 {

--- a/Gui/Plotter/qcustomplot.h
+++ b/Gui/Plotter/qcustomplot.h
@@ -3814,6 +3814,7 @@ protected:
   virtual void mouseMoveEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
   virtual void mouseReleaseEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
   virtual void wheelEvent(QWheelEvent *event) Q_DECL_OVERRIDE;
+  virtual bool event( QEvent *event ) Q_DECL_OVERRIDE;
   
   // introduced virtual methods:
   virtual void draw(QCPPainter *painter);
@@ -3845,6 +3846,10 @@ protected:
   friend class QCPAbstractPlottable;
   friend class QCPGraph;
   friend class QCPAbstractItem;
+
+private:
+    QPointF currentTouchPointPos;
+
 };
 Q_DECLARE_METATYPE(QCustomPlot::LayerInsertMode)
 Q_DECLARE_METATYPE(QCustomPlot::RefreshPriority)

--- a/Gui/Plotter/qcustomplot.h
+++ b/Gui/Plotter/qcustomplot.h
@@ -3814,7 +3814,7 @@ protected:
   virtual void mouseMoveEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
   virtual void mouseReleaseEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
   virtual void wheelEvent(QWheelEvent *event) Q_DECL_OVERRIDE;
-  virtual bool event( QEvent *event ) Q_DECL_OVERRIDE;
+  virtual bool event(QEvent *event) Q_DECL_OVERRIDE;
   
   // introduced virtual methods:
   virtual void draw(QCPPainter *painter);
@@ -3849,6 +3849,7 @@ protected:
 
 private:
     QPointF currentTouchPointPos;
+    bool gestureEvent(QGestureEvent *event);
 
 };
 Q_DECLARE_METATYPE(QCustomPlot::LayerInsertMode)

--- a/explanationOfGeneratedFiles.txt
+++ b/explanationOfGeneratedFiles.txt
@@ -1,0 +1,12 @@
+AerOpt_InputParameters: Input parameters for an optimisation
+			In particular,
+			IV%NoCN = number of control nodes
+			IV%xrange = control point x boundary coordinates in format "minimumx maximumx"
+			IV%yrange = control point y boundary coordinates in format "minimumy maximumy"
+			IV%NoNests = number of agents
+			IV%NoG = number of generations
+Control_Nodes: Coordinates of control points in format: "X	Y"
+
+profilePoints: Initial profile that is being optimised. E.g. NACA0024 or NACA21120
+Fitness_0: Fitness of initial profile
+FitnessAll: Fitness of each agent in each generation in format "generationNumber     Ag1     ...	Agn"

--- a/main.cpp
+++ b/main.cpp
@@ -134,6 +134,10 @@ void firstTimeSetup(QString AerOptWorkDir) {
     AerOptNodeFile = QDir::toNativeSeparators(AerOptNodeFile);
     settings.setValue("AerOpt/nodeFile", AerOptNodeFile);
 
+    QString AerOptBoundaryFile = inFolder + "Boundary_Points.txt";
+    AerOptBoundaryFile = QDir::toNativeSeparators(AerOptBoundaryFile);
+    settings.setValue("AerOpt/boundaryFile", AerOptBoundaryFile);
+
     // mesh is created in a scratch directory
     QString scratchPath = QDir::toNativeSeparators(AerOptWorkDir + "Scratch/");
     settings.setValue("mesher/scratchDir", scratchPath);

--- a/main.cpp
+++ b/main.cpp
@@ -186,7 +186,7 @@ int main(int argc, char *argv[])
     checkSettings();
 
     //Application main interaction classes.
-    DebugOutput::Instance();
+    //DebugOutput::Instance();
     qInfo() << " *** Welcome to AerOpt ***";
     qInfo() << " ***     Have a nice day     ***";
 


### PR DESCRIPTION
Features include:

Parallel Coordinates (PC) Graph 
- New window displaying the normalised displacement of boundary points from their original location for the best agent in each generation
- Displacement values are normalised according to the range of displacement values from their original location, not by control point bounding boxes
- Lines on chart are coloured according to a fitness value normalised by the range of fitness values for the best agent in each generation
- Graph updates in real-time in terms of lines plotted and the colour of lines and can show incomplete optimisations
- Window includes button to switch between showing control points only, or all boundary points on graph
- Main window includes a button to open the PC Window in the toolbar if closed
- Graph can be zoomed with the mouse wheel, and panned using click-and-drag
- Graph is touch-compatible (explained further below)

Touch Screen Functionality
- Parallel Coordinates Graph is touch-compatible including pinch-to-zoom, and panning
- Mesh View is touch compatible including pinch-to-zoom, and panning
- Control Points now have tap-and-hold functionality to activate/de-activate them (also mouse compatible)
- Fitness graph is touch-compatible, but slightly inconsistent in functionality due to underlying qcustomplot. To pinch-and-zoom, keep one finger still whilst the other moves otherwise mistaken for a pan and the interface gets confused

Minor Fixes
- Broken zooming on fitness graph has been fixed